### PR TITLE
feat(header): add breadcrumb link back to robotics-study hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 **/build
 **/dist
 **/__pycache__
+
+# Playwright MCP output + root-level verification screenshots
+.playwright-mcp
+/*.png

--- a/document/src/components/Header.tsx
+++ b/document/src/components/Header.tsx
@@ -4,6 +4,9 @@ import {useChapterNav} from "../libs/nav";
 
 const REPO = "https://github.com/robotics-study/modern_robotics"
 const TEXTBOOK = "https://hades.mech.northwestern.edu/index.php/Modern_Robotics"
+// 상위 학습 아카이브(robotics-study.github.io). 이 앱은 그 하위 프로젝트라 브랜드만으로는
+// 허브로 되돌아갈 방법이 없어, 브레드크럼 부모 링크로 탈출로를 제공한다.
+const HUB = "https://robotics-study.github.io/"
 
 const ExtIcon = () => (
     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
@@ -27,10 +30,16 @@ const Header = ({onMenu, showMenu}: { onMenu: () => void; showMenu: boolean }) =
                 </button>
             )}
 
-            <button className="brand" onClick={() => go(null)} aria-label="Home">
-                <BrandLogo gradId="mrBrandLogo"/>
-                <span className="wm">modern<span className="wm-dim"> robotics</span></span>
-            </button>
+            <div className="brandcrumb">
+                <a className="brand hub" href={HUB} aria-label="robotics-study home">
+                    <BrandLogo gradId="mrBrandLogo"/>
+                    <span className="wm">robotics<span className="wm-dim"> study</span></span>
+                </a>
+                <span className="crumb-sep" aria-hidden="true">/</span>
+                <button className="brand" onClick={() => go(null)} aria-label="Home">
+                    <span className="wm">modern<span className="wm-dim"> robotics</span></span>
+                </button>
+            </div>
 
             <nav className="topnav">
                 <a onClick={() => go(null)}>Overview</a>

--- a/document/src/index.css
+++ b/document/src/index.css
@@ -107,6 +107,20 @@
     border-bottom: 1px solid var(--border);
 }
 
+.brandcrumb {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.crumb-sep {
+    color: color-mix(in srgb, var(--muted) 45%, transparent);
+    font-size: 1rem;
+    font-weight: 400;
+    user-select: none;
+}
+
 .brand {
     display: flex;
     align-items: center;
@@ -132,6 +146,7 @@
 
 .brand .wm {
     letter-spacing: -.01em;
+    white-space: nowrap;
 }
 
 .brand .wm-dim {
@@ -962,6 +977,24 @@ a.mini-chip:hover {
 
     .topnav,
     .search {
+        display: none;
+    }
+
+    /* 메뉴 버튼까지 얹히는 모바일 폭에서 브레드크럼이 두 줄로 접히지 않도록 간격을 조인다. */
+    .topbar {
+        gap: 12px;
+        padding: 0 14px;
+    }
+
+    .brandcrumb {
+        gap: 8px;
+    }
+}
+
+/* 아주 좁은 폭에서는 허브 워드마크/구분자를 접고 로고만 허브 링크로 남긴다. */
+@media (max-width: 430px) {
+    .hub .wm,
+    .crumb-sep {
         display: none;
     }
 


### PR DESCRIPTION
## 문제
이 문서 사이트는 `robotics-study.github.io/modern_robotics/` 하위 프로젝트인데, 헤더의 브랜드·Overview가 모두 앱 내부(`/`)로만 이동해 상위 허브 `robotics-study.github.io/`로 되돌아갈 방법이 없었습니다.

## 변경
헤더에 브레드크럼 부모 링크를 추가했습니다: `[로고] robotics study / modern robotics`

- 좌측 묶음(로고 + "robotics study")은 허브 `https://robotics-study.github.io/`로 나가는 링크. 허브 원본 브랜드와 동일하게 `.brand` 스타일 재사용(`robotics` 볼드 + dim ` study`, 로고 26px).
- 우측 `modern robotics`는 기존대로 현재 앱 홈(`go(null)`).
- 구분자는 muted 톤의 `/`.

## 반응형
- 요소가 늘어 모바일에서 워드마크가 두 줄로 깨지던 문제 → `white-space: nowrap` + 모바일 간격 축소.
- 아주 좁은 폭(≤430px)에서는 "robotics study" 텍스트·구분자를 접고 로고를 허브 링크로 유지 (`☰ [로고] modern robotics`).

## 검증
- Playwright 실조작: 데스크톱 1280 / 모바일 500·390 / 다크모드 — 한 줄, 겹침 없음.
- 허브 앵커 `href = https://robotics-study.github.io/` 확인.
- `tsc --noEmit` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)