### PR TITLE
feat(canvas): 다크모드 색 반영 + 챕터 캔버스 클릭 확대 모달

### DIFF
--- a/document/src/components/2d/CoordinateCanvas.tsx
+++ b/document/src/components/2d/CoordinateCanvas.tsx
@@ -2,6 +2,7 @@ import {ReactNode} from 'react';
 import {Stage, Layer, Line, Text} from 'react-konva';
 import {StageProps} from "react-konva/ReactKonvaCore";
 import cn from "../../libs/cn";
+import {useCanvasColors} from "../../libs/useTheme";
 
 // width/height 는 좌표계 렌더에 필수다(originX = width/2 등). Konva StageProps 에서는
 // optional 이라 여기서 required 로 좁힌다 — 호출부는 항상 픽셀 크기를 넘긴다.
@@ -22,6 +23,7 @@ const CoordinateSystem = ({
                               tickLength = 10,
                               ...props
                           }: CoordinateSystemProps) => {
+    const colors = useCanvasColors();
     const originX = width / 2;
     const originY = height / 2;
     const tickInterval = 1 / resolution; // 눈금 간격
@@ -49,7 +51,7 @@ const CoordinateSystem = ({
                     <Line
                         key={`tick-${i}`}
                         points={[x, originY - tickLength / 2, x, originY + tickLength / 2]}
-                        stroke="black"
+                        stroke={colors.text}
                     />
                 );
                 if (i !== 0) {
@@ -60,7 +62,7 @@ const CoordinateSystem = ({
                             x={x + 5}
                             y={originY + 5}
                             fontSize={tickCount}
-                            fill="black"
+                            fill={colors.text}
                         />
                     );
                 }
@@ -70,7 +72,7 @@ const CoordinateSystem = ({
                     <Line
                         key={`tick-${i}`}
                         points={[originX - tickLength / 2, y, originX + tickLength / 2, y]}
-                        stroke="black"
+                        stroke={colors.text}
                     />
                 );
                 if (i !== 0) {
@@ -81,7 +83,7 @@ const CoordinateSystem = ({
                             x={originX + tickCount}
                             y={y - 5}
                             fontSize={tickCount}
-                            fill="black"
+                            fill={colors.text}
                         />
                     );
                 }
@@ -98,9 +100,9 @@ const CoordinateSystem = ({
             {...props}>
             <Layer>
                 {/* x축 */}
-                <Line points={xAxis.flatMap((p) => [p.x, p.y])} stroke="black"/>
+                <Line points={xAxis.flatMap((p) => [p.x, p.y])} stroke={colors.text}/>
                 {/* y축 */}
-                <Line points={yAxis.flatMap((p) => [p.x, p.y])} stroke="black"/>
+                <Line points={yAxis.flatMap((p) => [p.x, p.y])} stroke={colors.text}/>
 
                 {/* x축 눈금 */}
                 {renderTicks('x', Math.floor(width / tickInterval))}

--- a/document/src/components/3d/Physics3DCanvas.tsx
+++ b/document/src/components/3d/Physics3DCanvas.tsx
@@ -5,17 +5,26 @@ import {CannonJSPlugin, Color3, Color4, Scene as BabylonScene, Vector3} from "@b
 
 import cn from "../../libs/cn";
 import {GridMaterial} from "@babylonjs/materials";
+import {useTheme} from "../../libs/useTheme";
+
+// 캔버스는 CSS 변수를 못 읽으므로 테마별 배경/그리드 색을 여기서 직접 정의한다.
+const SCENE_THEME = {
+    dark: {clear: new Color4(0.02, 0.02, 0.02, 1), grid: new Color3(0.02, 0.02, 0.02)},
+    light: {clear: new Color4(0.97, 0.98, 0.99, 1), grid: new Color3(0.97, 0.98, 0.99)},
+} as const;
 
 const Ground = ({
                     name,
                     yzPlane,
                     zxPlain,
-                    opacity
+                    opacity,
+                    mainColor
                 }: {
     name: string,
     yzPlane?: boolean
     zxPlain?: boolean
     opacity?: number
+    mainColor: Color3
 }) => {
     return <ground
         rotation={zxPlain ? new Vector3(Math.PI / 2, 0, 0) : (yzPlane ? new Vector3(0, 0, Math.PI / 2) : Vector3.Zero())}
@@ -30,7 +39,7 @@ const Ground = ({
             gridMaterial.majorUnitFrequency = 5;
             gridMaterial.minorUnitVisibility = 0.5;
             gridMaterial.lineColor = zxPlain ? new Color3(0.4, 0, 0.4) : (yzPlane ? new Color3(0.4, 0.4, 0) : new Color3(0, 0.4, 0.4))
-            gridMaterial.mainColor = new Color3(0, 0, 0)
+            gridMaterial.mainColor = mainColor
             gridMaterial.backFaceCulling = false
             gridMaterial.opacity = opacity ?? 0.5
             instance.material = gridMaterial
@@ -47,6 +56,8 @@ const Content = ({
                      initialView
                  }: Physics3DCanvasProps) => {
     const sceneRef = useRef<BabylonScene>();
+    const theme = useTheme();
+    const palette = SCENE_THEME[theme];
 
     useEffect(() => {
         if (!window.CANNON && physics) {
@@ -54,13 +65,17 @@ const Content = ({
             sceneRef.current?.enablePhysics(new Vector3(0, -9.82, 0), new CannonJSPlugin());
         }
     }, []);
+    // Scene 은 clearColor 를 최초 1회만 읽으므로, 테마가 바뀌면 이미 만들어진 scene 에도 반영한다.
+    useEffect(() => {
+        if (sceneRef.current) sceneRef.current.clearColor = palette.clear;
+    }, [palette]);
     return <>
         <div
             className={cn(className, "overflow-hidden")}
         >
             <Engine antialias>
                 <Scene
-                    clearColor={new Color4(0.02, 0.02, 0.02, 0.93)}
+                    clearColor={palette.clear}
                     onCreated={(scene) => {
                         sceneRef.current = scene
                     }}
@@ -85,15 +100,15 @@ const Content = ({
                     {
                         ground ? <>
                             {(typeof ground == "object" && 'xy' in ground && ground.xy) ?
-                                <Ground name="xyGround"
+                                <Ground name="xyGround" mainColor={palette.grid}
                                         opacity={typeof ground.xy === "object" ? ground.xy.opacity : undefined}/> :
-                                <Ground name="xyGround"
+                                <Ground name="xyGround" mainColor={palette.grid}
                                         opacity={typeof ground == "object" ? ground.opacity : undefined}/>}
                             {(typeof ground == "object" && 'yz' in ground && ground.yz) ?
-                                <Ground name="yzGround" yzPlane
+                                <Ground name="yzGround" yzPlane mainColor={palette.grid}
                                         opacity={typeof ground.yz === "object" ? ground.yz.opacity : undefined}/> : null}
                             {(typeof ground == "object" && 'xz' in ground && ground.xz) ?
-                                <Ground name="xzGround" zxPlain
+                                <Ground name="xzGround" zxPlain mainColor={palette.grid}
                                         opacity={typeof ground.xz === "object" ? ground.xz.opacity : undefined}/> : null}
                         </> : null
                     }

--- a/document/src/components/CanvasFigure.tsx
+++ b/document/src/components/CanvasFigure.tsx
@@ -1,0 +1,49 @@
+import {ReactNode, useState} from "react";
+import cn from "../libs/cn";
+import Modal from "./Modal";
+
+interface CanvasFigureProps {
+    label: string;
+    // 인라인 썸네일로 렌더할 캔버스.
+    children: ReactNode;
+    // 모달용 확대 캔버스. 생략하면 children 을 큰 컨테이너에 그대로 재사용한다.
+    modal?: ReactNode;
+    // 외곽 래퍼(레이아웃 폭 등).
+    className?: string;
+    // 모달 내부 캔버스 컨테이너 크기.
+    bodyClassName?: string;
+    // 고정 픽셀 크기 캔버스(예: Konva)는 래퍼를 콘텐츠에 밀착시켜 zoom 버튼이 캔버스 모서리에 붙게 한다.
+    tight?: boolean;
+}
+
+const ZoomIcon = () => (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="11" cy="11" r="7"/>
+        <path d="m21 21-4.3-4.3M11 8v6M8 11h6"/>
+    </svg>
+);
+
+const CanvasFigure = ({label, children, modal, className, bodyClassName, tight}: CanvasFigureProps) => {
+    const [open, setOpen] = useState(false);
+    return (
+        <div className={cn("flex flex-col items-center justify-center p-3 gap-1", className)}>
+            <div className={cn("relative group", tight ? "w-fit max-w-full" : "w-full")}>
+                {children}
+                <button type="button" className="canvas-zoom-btn" onClick={() => setOpen(true)}
+                        aria-label={`Expand ${label}`}>
+                    <ZoomIcon/>
+                </button>
+            </div>
+            <span className="text-xs text-muted">{label}</span>
+            <Modal open={open} onClose={() => setOpen(false)} title={label}>
+                <div className={cn("mx-auto", bodyClassName ?? "w-[min(80vmin,560px)] aspect-square")}>
+                    {/* 열렸을 때만 확대 인스턴스를 마운트한다 (불필요한 WebGL 컨텍스트 방지). */}
+                    {open ? (modal ?? children) : null}
+                </div>
+            </Modal>
+        </div>
+    );
+};
+
+export default CanvasFigure;

--- a/document/src/components/Modal.tsx
+++ b/document/src/components/Modal.tsx
@@ -1,0 +1,48 @@
+import {ReactNode, useEffect} from "react";
+import {createPortal} from "react-dom";
+
+interface ModalProps {
+    open: boolean;
+    onClose: () => void;
+    title?: string;
+    children: ReactNode;
+}
+
+const Modal = ({open, onClose, title, children}: ModalProps) => {
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onClose();
+        };
+        document.addEventListener("keydown", onKey);
+        // 모달 열림 동안 배경 스크롤을 잠근다.
+        const prevOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        return () => {
+            document.removeEventListener("keydown", onKey);
+            document.body.style.overflow = prevOverflow;
+        };
+    }, [open, onClose]);
+
+    if (!open) return null;
+    return createPortal(
+        <div className="canvas-modal-backdrop" onClick={onClose}>
+            <div className="canvas-modal" role="dialog" aria-modal="true" aria-label={title}
+                 onClick={(e) => e.stopPropagation()}>
+                <div className="canvas-modal-head">
+                    <span className="canvas-modal-title">{title}</span>
+                    <button type="button" className="canvas-modal-close" onClick={onClose} aria-label="Close">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                             strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M18 6 6 18M6 6l12 12"/>
+                        </svg>
+                    </button>
+                </div>
+                <div className="canvas-modal-body">{children}</div>
+            </div>
+        </div>,
+        document.body,
+    );
+};
+
+export default Modal;

--- a/document/src/components/pages/chapter2/CoordinateExample.tsx
+++ b/document/src/components/pages/chapter2/CoordinateExample.tsx
@@ -3,121 +3,135 @@ import {Group, Line, Rect, Text, Transformer} from 'react-konva';
 import {useEffect, useMemo, useRef} from "react";
 import Konva from "konva";
 import {globalToMap, mapToGlobal} from "../../../libs/konvaUtils";
+import {useCanvasColors} from "../../../libs/useTheme";
+import CanvasFigure from "../../CanvasFigure";
 
 interface CoordinateExampleProps {
     className: string
 }
 
-const WIDTH = 300
-const HEIGHT = 300
 const RESOLUTION = 0.05
 
-const CoordinateExample = ({
-                               className
-                           }: CoordinateExampleProps) => {
+interface CoordinateStageProps {
+    width: number
+    height: number
+    className?: string
+}
+
+// 드래그 가능한 좌표계 씬. 인라인 썸네일과 모달 확대본이 서로 다른 픽셀 크기로 두 번 렌더된다.
+const CoordinateStage = ({width, height, className}: CoordinateStageProps) => {
+    const colors = useCanvasColors()
     const objectRef = useRef<Konva.Rect | null>(null)
     const transformerRef = useRef<Konva.Transformer | null>(null);
     const lineRef = useRef<Konva.Line | null>(null);
     const positionTextRef = useRef<Konva.Text | null>(null);
     const angleTextRef = useRef<Konva.Text | null>(null);
-    const position = useMemo(() => globalToMap(WIDTH, HEIGHT, 5, 5), [])
-    const origin = useMemo(() => {
-        return globalToMap(WIDTH, HEIGHT, 0, 0)
-    }, [])
+    const position = useMemo(() => globalToMap(width, height, 5, 5), [width, height])
+    const origin = useMemo(() => globalToMap(width, height, 0, 0), [width, height])
     useEffect(() => {
         if (objectRef.current && transformerRef.current) {
             transformerRef.current!.nodes([objectRef.current!!])
             transformerRef.current!.getLayer()!.batchDraw()
         }
     }, []);
-    return <div className="flex flex-col items-center justify-center py-3 gap-1">
-        <CoordinateSystem
-            resolution={RESOLUTION}
-            className={className}
-            width={WIDTH}
-            height={HEIGHT}
+    return <CoordinateSystem
+        resolution={RESOLUTION}
+        className={className}
+        width={width}
+        height={height}
+        draggable
+        offsetY={-100}
+        offsetX={100}>
+        <Line
+            ref={lineRef}
+            points={[origin.x, origin.y, position.x, position.y]}
+            stroke={colors.accent}
+        />
+        <Group
+            x={position.x}
+            y={position.y}
             draggable
-            offsetY={-100}
-            offsetX={100}>
-            <Line
-                ref={lineRef}
-                points={[origin.x, origin.y, position.x, position.y]}
-                stroke="blue"
-            />
+            onDragMove={evt => {
+                const x = evt.target!.x()
+                const y = evt.target!.y()
+                const mp = mapToGlobal(width, height, x, y)
+                positionTextRef.current!.text(`[x : ${mp.x.toFixed(2)}] [y: ${mp.y.toFixed(2)}]`)
+                lineRef.current!.points([origin.x, origin.y, x, y])
+            }}
+        >
             <Group
-                x={position.x}
-                y={position.y}
-                draggable
-                onDragMove={evt => {
-                    const x = evt.target!.x()
-                    const y = evt.target!.y()
-                    const mp = mapToGlobal(WIDTH, HEIGHT, x, y)
-                    positionTextRef.current!.text(`[x : ${mp.x.toFixed(2)}] [y: ${mp.y.toFixed(2)}]`)
-                    lineRef.current!.points([origin.x, origin.y, x, y])
-                }}
+                x={0}
+                y={40}
             >
-                <Group
-                    x={0}
-                    y={40}
-                >
-                    <Rect
-                        offsetX={75}
-                        width={150}
-                        height={40}
-                        x={0}
-                        fill="white"
-                        cornerRadius={10}
-                        stroke="black"
-                        strokeWidth={1}
-                    />
-                    <Text
-                        ref={positionTextRef}
-                        text={`[x : 5.00] [y: 5.00]`}
-                        x={0}
-                        y={8}
-                        width={150}
-                        offsetX={77}
-                        fontSize={12}
-                        fontStyle="bold"
-                        align="center"
-                    />
-                    <Text
-                        ref={angleTextRef}
-                        offsetX={77}
-                        text={`[th: 90.00 deg]`}
-                        x={0}
-                        y={22}
-                        width={150}
-                        fontSize={12}
-                        fontStyle="bold"
-                        align="center"
-                    />
-                </Group>
                 <Rect
-                    ref={objectRef}
-                    width={30}
-                    height={60}
+                    offsetX={75}
+                    width={150}
+                    height={40}
                     x={0}
-                    y={0}
-                    offsetX={15}
-                    offsetY={30}
-                    fill="red"
+                    fill={colors.surface}
+                    cornerRadius={10}
+                    stroke={colors.border}
+                    strokeWidth={1}
+                />
+                <Text
+                    ref={positionTextRef}
+                    text={`[x : 5.00] [y: 5.00]`}
+                    x={0}
+                    y={8}
+                    width={150}
+                    offsetX={77}
+                    fontSize={12}
+                    fontStyle="bold"
+                    fill={colors.text}
+                    align="center"
+                />
+                <Text
+                    ref={angleTextRef}
+                    offsetX={77}
+                    text={`[th: 90.00 deg]`}
+                    x={0}
+                    y={22}
+                    width={150}
+                    fontSize={12}
+                    fontStyle="bold"
+                    fill={colors.text}
+                    align="center"
                 />
             </Group>
-            <Transformer
-                ref={transformerRef}
-                rotateEnabled
-                onTransform={evt => {
-                    const th = 90 - evt.target.getAbsoluteRotation()
-                    angleTextRef.current!.text(`[th : ${th.toFixed(2)} deg]`)
-                }}
-                resizeEnabled={false}
-            >
-            </Transformer>
+            <Rect
+                ref={objectRef}
+                width={30}
+                height={60}
+                x={0}
+                y={0}
+                offsetX={15}
+                offsetY={30}
+                fill={colors.accent}
+            />
+        </Group>
+        <Transformer
+            ref={transformerRef}
+            rotateEnabled
+            onTransform={evt => {
+                const th = 90 - evt.target.getAbsoluteRotation()
+                angleTextRef.current!.text(`[th : ${th.toFixed(2)} deg]`)
+            }}
+            resizeEnabled={false}
+        >
+        </Transformer>
+    </CoordinateSystem>
+}
 
-        </CoordinateSystem>
-        <span className="text-xs text-muted">coordinate</span>
-    </div>
+const CoordinateExample = ({className}: CoordinateExampleProps) => {
+    return <CanvasFigure
+        label="coordinate"
+        tight
+        bodyClassName="w-fit"
+        modal={<CoordinateStage width={520} height={520}
+                                className="bg-surface border border-border rounded-lg"/>}
+    >
+        <CoordinateStage width={300} height={300} className={className}/>
+    </CanvasFigure>
 }
 
 export default CoordinateExample

--- a/document/src/components/pages/chapter2/CylindricalJoint.tsx
+++ b/document/src/components/pages/chapter2/CylindricalJoint.tsx
@@ -1,4 +1,5 @@
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
 import {Animation, Color3, IAnimationKey, Mesh, Vector3} from "@babylonjs/core";
 import {ReactNode, useCallback} from "react";
 import {useScene} from "react-babylonjs";
@@ -91,7 +92,7 @@ const CylindricalLink = ({
     </mesh>
 }
 const CylindricalJoint = () => {
-    return <div className="flex flex-col items-center justify-center p-3 w-1/2 md:w-1/4 gap-1">
+    return <CanvasFigure label="cylindrical joint" className="w-1/2 md:w-1/4">
         <Physics3DCanvas
             className="aspect-square w-full rounded-lg"
             initialView={{
@@ -176,8 +177,7 @@ const CylindricalJoint = () => {
                 </cylinder>
             </CylindricalLink>
         </Physics3DCanvas>
-        <span className="text-xs text-muted">cylindrical joint</span>
-    </div>
+    </CanvasFigure>
 }
 
 export default CylindricalJoint

--- a/document/src/components/pages/chapter2/HelicalJoint.tsx
+++ b/document/src/components/pages/chapter2/HelicalJoint.tsx
@@ -1,4 +1,5 @@
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
 import {Animation, Color3, IAnimationKey, Mesh, StandardMaterial, Vector3, VertexData} from "@babylonjs/core";
 import {useCallback} from "react";
 import {useScene} from "react-babylonjs";
@@ -185,7 +186,7 @@ const HelicalLink = ({
     </box>
 }
 const HelicalJoint = () => {
-    return <div className="flex flex-col items-center justify-center p-3 w-1/2 md:w-1/4 gap-1">
+    return <CanvasFigure label="helical joint" className="w-1/2 md:w-1/4">
         <Physics3DCanvas
             className="aspect-square w-full rounded-lg"
             initialView={{
@@ -215,8 +216,7 @@ const HelicalJoint = () => {
                 direction={-1}
             />
         </Physics3DCanvas>
-        <span className="text-xs text-muted">helical joint</span>
-    </div>
+    </CanvasFigure>
 }
 
 export default HelicalJoint

--- a/document/src/components/pages/chapter2/PrismaticJoint.tsx
+++ b/document/src/components/pages/chapter2/PrismaticJoint.tsx
@@ -1,4 +1,5 @@
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
 import {Animation, Color3, IAnimationKey, Mesh, Vector3} from "@babylonjs/core";
 import {useCallback} from "react";
 import {useScene} from "react-babylonjs";
@@ -62,7 +63,7 @@ const PrismaticLink = ({
     </box>
 }
 const PrismaticJoint = () => {
-    return <div className="flex flex-col items-center justify-center p-3 w-1/2 md:w-1/4 gap-1">
+    return <CanvasFigure label="prismatic joint" className="w-1/2 md:w-1/4">
         <Physics3DCanvas
             className="aspect-square w-full rounded-lg"
             initialView={{
@@ -93,8 +94,7 @@ const PrismaticJoint = () => {
                 direction={1}
             />
         </Physics3DCanvas>
-        <span className="text-xs text-muted">prismatic joint</span>
-    </div>
+    </CanvasFigure>
 }
 
 export default PrismaticJoint

--- a/document/src/components/pages/chapter2/RevoluteJoint.tsx
+++ b/document/src/components/pages/chapter2/RevoluteJoint.tsx
@@ -1,4 +1,5 @@
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
 import {Animation, Color3, IAnimationKey, Mesh, Vector3} from "@babylonjs/core";
 import {useCallback} from "react";
 import {useScene} from "react-babylonjs";
@@ -65,7 +66,7 @@ const RevoluteLink = ({
     </box>
 }
 const RevoluteJoint = () => {
-    return <div className="flex flex-col items-center justify-center p-3 w-1/2 md:w-1/4 gap-1">
+    return <CanvasFigure label="revolute joint" className="w-1/2 md:w-1/4">
         <Physics3DCanvas
             className="aspect-square w-full rounded-lg"
             initialView={{
@@ -94,8 +95,7 @@ const RevoluteJoint = () => {
                 direction={-1}
             />
         </Physics3DCanvas>
-        <span className="text-xs text-muted">revolute joint</span>
-    </div>
+    </CanvasFigure>
 }
 
 export default RevoluteJoint

--- a/document/src/components/pages/chapter2/SphericalJoint.tsx
+++ b/document/src/components/pages/chapter2/SphericalJoint.tsx
@@ -1,4 +1,5 @@
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
 import {Animation, Color3, IAnimationKey, Vector3} from "@babylonjs/core";
 import {useCallback} from "react";
 import {useScene} from "react-babylonjs";
@@ -85,7 +86,7 @@ const SphericalLink = ({
     </mesh>
 }
 const SphericalJoint = () => {
-    return <div className="flex flex-col items-center justify-center p-3 w-1/2 md:w-1/4 gap-1">
+    return <CanvasFigure label="spherical joint" className="w-1/2 md:w-1/4">
         <Physics3DCanvas
             className="aspect-square w-full rounded-lg"
             initialView={{
@@ -226,8 +227,7 @@ const SphericalJoint = () => {
             >
             </SphericalLink>
         </Physics3DCanvas>
-        <span className="text-xs text-muted">spherical joint</span>
-    </div>
+    </CanvasFigure>
 }
 
 export default SphericalJoint

--- a/document/src/components/pages/chapter2/UniversalJoint.tsx
+++ b/document/src/components/pages/chapter2/UniversalJoint.tsx
@@ -1,10 +1,11 @@
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
 import LoadedModel from "../../3d/LoadedModel";
 import {Animation, Color3, IAnimationKey, Vector3} from "@babylonjs/core";
 
 const UniversalJoint = () => {
 
-    return <div className="flex flex-col items-center justify-center p-3 w-1/2 md:w-1/4 gap-1">
+    return <CanvasFigure label="universal joint" className="w-1/2 md:w-1/4">
         <Physics3DCanvas
             className="aspect-square w-full rounded-lg"
             initialView={{
@@ -101,8 +102,7 @@ const UniversalJoint = () => {
                 }}
             />
         </Physics3DCanvas>
-        <span className="text-xs text-muted">universal joint</span>
-    </div>
+    </CanvasFigure>
 }
 
 

--- a/document/src/index.css
+++ b/document/src/index.css
@@ -773,7 +773,7 @@ h3:hover .anchor {
     overflow: hidden;
     box-shadow: var(--shadow);
     margin-bottom: 52px;
-    background: #0b1020;
+    background: var(--surface);
 }
 
 .hero-3d canvas {
@@ -788,7 +788,7 @@ h3:hover .anchor {
     align-items: center;
     gap: 8px;
     font-size: .8rem;
-    color: rgba(230, 235, 245, .85);
+    color: var(--muted);
 }
 
 .hero-3d .hero-cap .dot {
@@ -941,6 +941,117 @@ a.mini-chip:hover {
 
 .site-footer a {
     color: var(--muted);
+}
+
+/* ---------- canvas figures (zoom → modal) ---------- */
+.canvas-zoom-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: color-mix(in srgb, var(--surface) 85%, transparent);
+    color: var(--muted);
+    cursor: zoom-in;
+    opacity: 0;
+    transition: opacity .16s, color .16s, border-color .16s;
+    backdrop-filter: blur(4px);
+    z-index: 2;
+}
+
+.group:hover .canvas-zoom-btn,
+.canvas-zoom-btn:focus-visible {
+    opacity: 1;
+}
+
+.canvas-zoom-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+/* 터치 기기는 hover 가 없으므로 버튼을 항상 노출한다. */
+@media (hover: none) {
+    .canvas-zoom-btn {
+        opacity: 1;
+    }
+}
+
+.canvas-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: grid;
+    place-items: center;
+    padding: 24px;
+    background: color-mix(in srgb, #05070f 62%, transparent);
+    backdrop-filter: blur(3px);
+    animation: canvas-modal-fade .16s ease;
+}
+
+.canvas-modal {
+    display: flex;
+    flex-direction: column;
+    max-width: min(92vw, 640px);
+    max-height: 90vh;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+}
+
+.canvas-modal-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 12px 12px 18px;
+    border-bottom: 1px solid var(--border);
+}
+
+.canvas-modal-title {
+    font-weight: 600;
+    font-size: .92rem;
+    text-transform: capitalize;
+    color: var(--text);
+}
+
+.canvas-modal-close {
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    flex: none;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: var(--surface);
+    color: var(--muted);
+    cursor: pointer;
+}
+
+.canvas-modal-close:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.canvas-modal-body {
+    padding: 18px;
+    overflow: auto;
+    display: grid;
+    place-items: center;
+}
+
+@keyframes canvas-modal-fade {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
 }
 
 /* mobile */

--- a/document/src/libs/useTheme.ts
+++ b/document/src/libs/useTheme.ts
@@ -1,0 +1,54 @@
+import {useEffect, useMemo, useState} from "react";
+
+export type Theme = "light" | "dark";
+
+// 캔버스(Konva/Babylon)는 CSS 변수를 못 읽으므로 현재 테마를 JS 로 직접 판정한다.
+// 우선순위: 명시적 data-theme 속성 > 시스템 prefers-color-scheme.
+function resolveTheme(): Theme {
+    const attr = document.documentElement.getAttribute("data-theme");
+    if (attr === "light" || attr === "dark") return attr;
+    return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function useTheme(): Theme {
+    const [theme, setTheme] = useState<Theme>(resolveTheme);
+    useEffect(() => {
+        const update = () => setTheme(resolveTheme());
+        const media = window.matchMedia("(prefers-color-scheme: dark)");
+        media.addEventListener("change", update);
+        // 향후 테마 토글이 data-theme 를 바꿀 때도 즉시 반영한다.
+        const observer = new MutationObserver(update);
+        observer.observe(document.documentElement, {attributes: true, attributeFilter: ["data-theme"]});
+        return () => {
+            media.removeEventListener("change", update);
+            observer.disconnect();
+        };
+    }, []);
+    return theme;
+}
+
+export interface CanvasColors {
+    text: string;
+    muted: string;
+    border: string;
+    surface: string;
+    bg: string;
+    accent: string;
+}
+
+// 캔버스에서 쓸 실제 색을 CSS 변수(단일 진실원본)에서 읽어온다. 테마가 바뀌면 재계산된다.
+export function useCanvasColors(): CanvasColors {
+    const theme = useTheme();
+    return useMemo(() => {
+        const style = getComputedStyle(document.documentElement);
+        const read = (name: string, fallback: string) => style.getPropertyValue(name).trim() || fallback;
+        return {
+            text: read("--text", "#0f172a"),
+            muted: read("--muted", "#5b6b82"),
+            border: read("--border", "#e2e8f0"),
+            surface: read("--surface", "#f8fafc"),
+            bg: read("--bg", "#ffffff"),
+            accent: read("--accent", "#6366f1"),
+        };
+    }, [theme]);
+}

--- a/document/src/pages/chapters/Chapter2.tsx
+++ b/document/src/pages/chapters/Chapter2.tsx
@@ -34,7 +34,7 @@ const Chapter2 = () => {
                 <InlineMath math='y = r \sin\theta'/>
             </p>
             <p>Drag the point below to see position and orientation change together.</p>
-            <CoordinateExample className="bg-white border border-border rounded-lg h-48"/>
+            <CoordinateExample className="bg-surface border border-border rounded-lg h-48"/>
 
             <h2>Degrees of Freedom of a Robot</h2>
             <p>


### PR DESCRIPTION
## 요약
Chapter 2의 캔버스(2D 좌표계, 3D 조인트)가 CSS 변수를 못 읽어 하드코딩 색으로 남아 사용자 테마(라이트/다크)를 따르지 않던 문제를 해결하고, 각 캔버스를 클릭하면 크게 확대해 그대로 조작할 수 있는 모달을 추가한다.

## 변경 사항
### 1) 캔버스 다크모드 반영
- `libs/useTheme.ts` (신규): `useTheme()`(시스템 `prefers-color-scheme` + `data-theme` 반응) / `useCanvasColors()`(CSS 토큰을 캔버스용 실제 색으로 해석, 단일 진실원본).
- **2D 좌표계**(`CoordinateCanvas`, `CoordinateExample`): 축·눈금·라벨·정보 버블·벡터/객체 색을 테마 색으로 (`black/white/red/blue` 하드코딩 제거). `Chapter2` 컨테이너 `bg-white` → `bg-surface`.
- **3D 캔버스**(`Physics3DCanvas`): 배경 clearColor·그리드 색을 라이트/다크 팔레트로 전환. `.hero-3d` 배경·캡션 색도 테마 변수로.

### 2) 클릭 → 확대 모달
- `components/Modal.tsx` (신규): 포털 기반, ESC/배경/✕ 닫기 + 배경 스크롤 잠금.
- `components/CanvasFigure.tsx` (신규): 캔버스 우상단 zoom 버튼(터치 기기 상시 노출) → 모달에 **확대된 인터랙티브 캔버스** 렌더(열렸을 때만 마운트해 불필요한 WebGL 컨텍스트 방지). 고정폭 캔버스용 `tight` 정렬 옵션.
- Chapter 2 좌표계 예제 + 조인트 6종을 `CanvasFigure`로 래핑(공용화, 중복 0).

## 검증
- `tsc --noEmit` / `vite build` 통과.
- 브라우저에서 라이트·다크 양쪽 좌표계·조인트 배경 전환, 3D/2D 확대 모달(드래그·회전 인터랙션 포함) 동작 확인, 콘솔 error/warning 0건.

## 참고
앱에 테마 토글이 없어 시스템 설정만 따른다. OS 테마를 실시간 전환하면 3D 배경은 즉시 바뀌지만 이미 생성된 그리드 평면 색은 재마운트 전까지 유지된다(초기 로드는 항상 정확).

🤖 Generated with [Claude Code](https://claude.com/claude-code)