### PR TITLE
feat: interactive visualizations for chapters 3 and 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+Guidance for working in this repo. See `README.md` for the full overview, tech stack, and
+project structure.
+
+## What this is
+
+Interactive study notes for Lynch & Park's *Modern Robotics*. Two parts:
+
+- `document/` — the deployed web app (React 18 + Vite 6 + TypeScript). All app work happens here.
+- `sample_code/` — standalone Python / C++ reference implementations, grouped by chapter.
+
+Chapters are pages addressed by query param: `…/?chapter=<N>`.
+
+## Chapters must be visual
+
+**Every chapter teaches visually, not just in prose.** Each major concept gets an interactive or
+animated figure — the way Chapter 2 does. When adding or expanding a chapter, add a visualization
+per key concept; do not ship a wall of equations without a figure that lets the reader *see* the
+idea.
+
+Choose the medium by the concept:
+
+- **3D / spatial** (rotations, `SE(3)`, screw motion, robot arms) → Babylon.js scene via
+  `components/3d/Physics3DCanvas`. Use `AxisTriad` for a movable body-frame axis triad.
+- **2D / planar** (coordinate frames, planar chains) → Konva scene via `components/2d/CoordinateCanvas`.
+
+Prefer **interactivity** (sliders / drag) when the concept has parameters the reader should sweep
+— e.g. the `e^[ω̂]θ` angle slider (Ch.3) and the 3R planar-chain joint sliders (Ch.4). Otherwise a
+looping **animation** (e.g. the rotating frame, screw-motion helix).
+
+## Conventions
+
+- **Wrap figures in `CanvasFigure`** — it adds the caption and the click-to-expand modal. The modal
+  mounts a *second, independent* instance, so a figure that keeps its own React state (sliders)
+  must be a self-contained component; pass a fresh instance as the `modal` prop.
+- **Reuse the shared scaffolding** — `Physics3DCanvas`, `AxisTriad`, `CoordinateCanvas`,
+  `konvaUtils` (`globalToMap` / `mapToGlobal`). Don't re-implement axes, grids, or coordinate math.
+- **Theme-aware colors** — canvases can't read CSS variables. Read colors from `useCanvasColors()`
+  (Konva) or the scene palette in `Physics3DCanvas` (Babylon) so figures render correctly in light
+  and dark mode. Never hard-code theme colors in a figure.
+- **Placement** — per-chapter figures live in `components/pages/chapter<N>/`; the chapter page
+  (`pages/chapters/Chapter<N>.tsx`) imports and drops them inline next to the relevant prose.
+- **3D assets** — STL models live in `document/public/`; load them with `LoadedModel` and
+  `resolvePath()` (never hard-code the `/modern_robotics` base path).
+- **Comments** explain *why*; identifiers and signatures carry the *what*.
+
+## Verify
+
+The dev server runs from `document/` (`yarn dev`). After changing a figure, load the affected
+chapter (`?chapter=<N>`) and confirm it renders and animates/reacts with no console errors — a
+passing `yarn build` / typecheck alone does not prove a canvas works. Run `yarn build` before
+opening a PR.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The web app presents each chapter as a page: prose + KaTeX-rendered equations, i
 | - | ---------------------- | -------------------------------------------------------------------------------------------- | ----------- |
 | 1 | Preview                | Landing / table of contents                                                                  | —           |
 | 2 | Configuration Space    | Degrees of freedom; revolute · prismatic · helical · cylindrical · universal · spherical joints (animated 3D); 2D coordinate example | Python      |
-| 3 | Rigid-Body Motions     | `SO(3)`, skew-symmetric `so(3)`, angular & linear velocity, exponential coordinates, twists  | C++         |
-| 4 | Forward Kinematics     | 🚧 Work in progress                                                                          | Python      |
+| 3 | Rigid-Body Motions     | `SO(3)`, skew-symmetric `so(3)`, angular & linear velocity, exponential coordinates, twists — with a rotating body frame, an interactive `e^[ω̂]θ` axis-angle slider, an `SE(3)` frame, and a screw-motion helix (animated 3D) | C++         |
+| 4 | Forward Kinematics     | Open-chain FK, product of exponentials, URDF — with an interactive 3R planar chain (Konva sliders → live end-effector pose) and an animated serial-chain robot (URDF link/joint tree) | Python      |
 
 > Chapters are addressed by query param, e.g. `…/modern_robotics/?chapter=2`.
 
@@ -112,13 +112,14 @@ modern_robotics/
 │       ├── components/
 │       │   ├── Header.tsx        # topbar: brand, breadcrumb, theme toggle
 │       │   ├── ChapterContents.tsx
-│       │   ├── 3d/               # Babylon canvas & model loaders
+│       │   ├── 3d/               # Babylon canvas, model loaders, AxisTriad (body-frame axes)
 │       │   ├── 2d/               # Konva coordinate canvas
 │       │   ├── math/             # KaTeX wrappers
-│       │   └── pages/chapter2/   # joint demos
+│       │   ├── CanvasFigure.tsx  # figure wrapper: caption + click-to-expand modal
+│       │   └── pages/chapter{2,3,4}/  # per-chapter interactive/animated visualizations
 │       └── pages/
 │           ├── home/             # chapter card grid
-│           └── chapters/         # Chapter{2,3,4}.tsx + lazy-loaded index
+│           └── chapters/         # Chapter{1,2,3,4}.tsx + lazy-loaded index
 └── sample_code/
     ├── chapter2/python/
     └── chapter3/
@@ -143,6 +144,22 @@ Pushing to `main` triggers `.github/workflows/deploy.yml`, which builds `documen
 2. Make changes under `document/` (and `sample_code/` if adding examples).
 3. Verify with `yarn build` and a quick `yarn preview` pass.
 4. Open a PR against `robotics-study/modern_robotics` `main`.
+
+### Authoring chapters
+
+Every chapter should **teach visually, not just in prose** — each major concept gets an
+interactive or animated figure, the way Chapter 2 does. When adding or expanding a chapter:
+
+- Add a visualization per key concept: a **Babylon.js** 3D scene (`components/3d/`) for
+  spatial ideas, or a **Konva** 2D scene (`components/2d/`) for planar ones. Prefer
+  interactivity (drag / sliders) where the concept has parameters; otherwise a looping
+  animation.
+- Wrap each figure in `CanvasFigure` (caption + click-to-expand modal) and reuse the shared
+  building blocks (`Physics3DCanvas`, `AxisTriad`, `CoordinateCanvas`) rather than
+  re-implementing scaffolding.
+- Read theme colors from `useCanvasColors()` / the scene palette so figures work in light and
+  dark mode; canvases can't read CSS variables directly.
+- Keep per-chapter figures under `components/pages/chapter<N>/`.
 
 ## License
 

--- a/document/src/components/3d/AxisTriad.tsx
+++ b/document/src/components/3d/AxisTriad.tsx
@@ -1,0 +1,57 @@
+import {Color3, TransformNode, Vector3} from "@babylonjs/core";
+import {Fragment} from "react";
+
+// body frame(움직이는 좌표계)을 화살표 3축으로 그린다. Physics3DCanvas 의 axis(고정 space frame)와
+// 대비되도록 짧은 화살표 + emissive 로 렌더한다. onReady 로 노드를 넘겨 부모가 회전/이동/애니메이션을 건다.
+interface AxisTriadProps {
+    name: string;
+    // 축 길이(홈 프레임 기준). 고정 축보다 짧게 잡아 화살표 끝이 보이게 한다.
+    size?: number;
+    radius?: number;
+    onReady?: (node: TransformNode) => void;
+}
+
+// Babylon cylinder 기본 축은 +Y. 각 축은 회전으로 +Y 를 목표 방향에 맞추고, position 으로 축을 따라 민다.
+const AXES = [
+    {key: "x", color: new Color3(0.9, 0.25, 0.25), rotation: new Vector3(0, 0, -Math.PI / 2), dir: new Vector3(1, 0, 0)},
+    {key: "y", color: new Color3(0.3, 0.8, 0.35), rotation: new Vector3(0, 0, 0), dir: new Vector3(0, 1, 0)},
+    {key: "z", color: new Color3(0.3, 0.45, 0.95), rotation: new Vector3(Math.PI / 2, 0, 0), dir: new Vector3(0, 0, 1)},
+] as const;
+
+const AxisTriad = ({name, size = 5, radius = 0.12, onReady}: AxisTriadProps) => {
+    const shaftLen = size * 0.82;
+    const tipLen = size * 0.18;
+    return (
+        <transformNode name={name} onCreated={(node: TransformNode) => onReady?.(node)}>
+            {AXES.map(({key, color, rotation, dir}) => (
+                <Fragment key={key}>
+                    <cylinder
+                        name={`${name}-${key}-shaft`}
+                        height={shaftLen}
+                        diameter={radius * 2}
+                        tessellation={16}
+                        rotation={rotation}
+                        position={dir.scale(shaftLen / 2)}
+                    >
+                        <standardMaterial name={`${name}-${key}-shaft-mat`} diffuseColor={color}
+                                          emissiveColor={color.scale(0.4)}/>
+                    </cylinder>
+                    <cylinder
+                        name={`${name}-${key}-tip`}
+                        height={tipLen}
+                        diameterTop={0}
+                        diameterBottom={radius * 4}
+                        tessellation={16}
+                        rotation={rotation}
+                        position={dir.scale(shaftLen + tipLen / 2)}
+                    >
+                        <standardMaterial name={`${name}-${key}-tip-mat`} diffuseColor={color}
+                                          emissiveColor={color.scale(0.4)}/>
+                    </cylinder>
+                </Fragment>
+            ))}
+        </transformNode>
+    );
+};
+
+export default AxisTriad;

--- a/document/src/components/XmlCode.tsx
+++ b/document/src/components/XmlCode.tsx
@@ -1,0 +1,64 @@
+import {Fragment, ReactNode} from "react";
+
+// 의존성 없이 XML/xacro 를 토큰별로 색칠한다. 색은 테마 CSS 변수(--tok-*)에서 읽어 라이트/다크 모두 대응.
+type TokClass = "comment" | "tag" | "attr" | "string" | "expr" | "punct" | "text";
+
+interface Tok {
+    c: TokClass;
+    t: string;
+}
+
+// 문자열 값 안의 xacro 식 ${...} 을 분리해 별도 색으로 칠한다.
+const splitExpr = (str: string, base: TokClass): Tok[] =>
+    str.split(/(\$\{[^}]*\})/).filter(Boolean).map((part) =>
+        part.startsWith("${") ? {c: "expr" as const, t: part} : {c: base, t: part});
+
+const tokenizeTag = (tag: string): Tok[] => {
+    const out: Tok[] = [];
+    const open = tag.match(/^<\/?/)![0];
+    out.push({c: "punct", t: open});
+    let rest = tag.slice(open.length);
+    const name = rest.match(/^[^\s>/]+/);
+    if (name) {
+        out.push({c: "tag", t: name[0]});
+        rest = rest.slice(name[0].length);
+    }
+    // 속성/문자열/연산자/닫는 괄호를 순서대로 소비한다. 마지막 [^] 로 남는 문자까지 흡수해 유실 방지.
+    const re = /("[^"]*")|('[^']*')|([A-Za-z_][\w:.-]*)|(=)|(\??\/?>)|(\s+)|([^])/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(rest))) {
+        if (m[1] || m[2]) out.push(...splitExpr(m[0], "string"));
+        else if (m[3]) out.push({c: "attr", t: m[3]});
+        else if (m[4] || m[5] || m[7]) out.push({c: "punct", t: m[0]});
+        else out.push({c: "text", t: m[0]});
+    }
+    return out;
+};
+
+const tokenize = (src: string): Tok[] => {
+    const out: Tok[] = [];
+    const re = /(<!--[\s\S]*?-->)|(<\/?[^>]+>)|([^<]+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src))) {
+        if (m[1]) out.push({c: "comment", t: m[1]});
+        else if (m[2]) out.push(...tokenizeTag(m[2]));
+        else out.push({c: "text", t: m[3]});
+    }
+    return out;
+};
+
+const renderTok = (tok: Tok, i: number): ReactNode =>
+    tok.c === "text"
+        ? <Fragment key={i}>{tok.t}</Fragment>
+        : <span key={i} style={{color: `var(--tok-${tok.c})`}}>{tok.t}</span>;
+
+interface XmlCodeProps {
+    code: string;
+    className?: string;
+}
+
+const XmlCode = ({code, className}: XmlCodeProps) => (
+    <pre className={className}><code>{tokenize(code).map(renderTok)}</code></pre>
+);
+
+export default XmlCode;

--- a/document/src/components/pages/chapter3/ExponentialRotation.tsx
+++ b/document/src/components/pages/chapter3/ExponentialRotation.tsx
@@ -1,0 +1,76 @@
+import {useEffect, useMemo, useRef, useState} from "react";
+import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import AxisTriad from "../../3d/AxisTriad";
+import {Color3, Quaternion, TransformNode, Vector3} from "@babylonjs/core";
+
+// 지수 좌표 R = e^[ω̂]θ 의 기하: 고정된 회전축 ω̂(주황 선) 둘레로 body frame 이 각 θ 만큼 돈다.
+// 슬라이더로 θ 를 직접 돌려 축-각 파라미터가 회전을 어떻게 만드는지 본다.
+const AXIS = new Vector3(0.35, 1, 0.3).normalize();
+
+const RotationAxisLine = () => (
+    <lines
+        name="omega-axis"
+        points={[AXIS.scale(-9), AXIS.scale(9)]}
+        color={new Color3(0.95, 0.65, 0.2)}
+    />
+);
+
+interface SceneProps {
+    canvasClassName: string;
+}
+
+const ExpRotationScene = ({canvasClassName}: SceneProps) => {
+    const [theta, setTheta] = useState(Math.PI / 2);
+    const nodeRef = useRef<TransformNode | null>(null);
+    const pose = useMemo(() => Quaternion.RotationAxis(AXIS, theta), [theta]);
+
+    useEffect(() => {
+        if (nodeRef.current) nodeRef.current.rotationQuaternion = pose;
+    }, [pose]);
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <Physics3DCanvas
+                className={canvasClassName}
+                initialView={{radius: 15, at: {x: 6, y: 6, z: 8}}}
+                axis
+                ground={{opacity: 0.6}}
+            >
+                <RotationAxisLine/>
+                <AxisTriad name="exp-body" size={5} onReady={(node: TransformNode) => {
+                    nodeRef.current = node;
+                    node.rotationQuaternion = pose;
+                }}/>
+            </Physics3DCanvas>
+            <div className="px-2 pb-1">
+                <input
+                    type="range"
+                    min={0}
+                    max={2 * Math.PI}
+                    step={0.01}
+                    value={theta}
+                    onChange={(e) => setTheta(parseFloat(e.target.value))}
+                    className="w-full accent-[var(--accent)]"
+                    aria-label="rotation angle theta"
+                />
+                <div className="text-xs text-muted text-center">
+                    θ = {theta.toFixed(2)} rad ({(theta * 180 / Math.PI).toFixed(0)}°) · ω̂ fixed
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const ExponentialRotation = () => {
+    return <CanvasFigure
+        label="exponential coordinates · R = e^[ω̂]θ"
+        className="w-full sm:w-2/3 mx-auto"
+        bodyClassName="w-[min(80vmin,520px)]"
+        modal={<ExpRotationScene canvasClassName="aspect-square w-full rounded-lg"/>}
+    >
+        <ExpRotationScene canvasClassName="aspect-square w-full rounded-lg"/>
+    </CanvasFigure>;
+};
+
+export default ExponentialRotation;

--- a/document/src/components/pages/chapter3/HomogeneousTransform.tsx
+++ b/document/src/components/pages/chapter3/HomogeneousTransform.tsx
@@ -1,0 +1,34 @@
+import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import AxisTriad from "../../3d/AxisTriad";
+import {Color3, Quaternion, TransformNode, Vector3} from "@babylonjs/core";
+
+// SE(3) 원소 T = (R, p): 고정 space frame {s}(원점) 대비 body frame {b} 가 방향 R 로 돌아가고
+// 위치 p 만큼 떨어져 있다. 이동벡터 p 를 선으로, 끝점을 구로 표시한다. 드래그로 궤도 회전.
+const P = new Vector3(5, 3, -3);
+const R = Quaternion.RotationAxis(new Vector3(0.3, 1, 0.4).normalize(), 0.9);
+
+const HomogeneousTransform = () => {
+    return <CanvasFigure label="SE(3) · T = (R, p)" className="w-full sm:w-2/3 mx-auto">
+        <Physics3DCanvas
+            className="aspect-square w-full rounded-lg"
+            initialView={{radius: 16, at: {x: 7, y: 6, z: 9}}}
+            axis
+            ground={{opacity: 0.6}}
+        >
+            {/* 원점에서 p 로 향하는 이동벡터 */}
+            <lines name="p-vector" points={[Vector3.Zero(), P]} color={new Color3(0.6, 0.55, 0.95)}/>
+            <sphere name="p-marker" diameter={0.5} position={P}>
+                <standardMaterial name="p-marker-mat" diffuseColor={new Color3(0.6, 0.55, 0.95)}
+                                  emissiveColor={new Color3(0.3, 0.28, 0.5)}/>
+            </sphere>
+            {/* p 에 놓인 body frame, 방향 R */}
+            <AxisTriad name="se3-body" size={4} onReady={(node: TransformNode) => {
+                node.position = P;
+                node.rotationQuaternion = R;
+            }}/>
+        </Physics3DCanvas>
+    </CanvasFigure>;
+};
+
+export default HomogeneousTransform;

--- a/document/src/components/pages/chapter3/RotatingFrame.tsx
+++ b/document/src/components/pages/chapter3/RotatingFrame.tsx
@@ -1,0 +1,37 @@
+import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import AxisTriad from "../../3d/AxisTriad";
+import {Animation, TransformNode} from "@babylonjs/core";
+import {useScene} from "react-babylonjs";
+
+// body frame {b} 가 고정 space frame {s} 대비 각속도 ω 로 연속 회전한다 (ω = ω̂ θ̇, 여기선 ω̂ = ŷ).
+const SpinningTriad = () => {
+    const scene = useScene();
+    return <AxisTriad name="rotating-body" size={5} onReady={(node: TransformNode) => {
+        const animation = new Animation(
+            "spin", "rotation.y", 30,
+            Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_CYCLE,
+        );
+        animation.setKeys([
+            {frame: 0, value: 0},
+            {frame: 240, value: 2 * Math.PI},
+        ]);
+        node.animations = [animation];
+        scene?.beginAnimation(node, 0, 240, true);
+    }}/>;
+};
+
+const RotatingFrame = () => {
+    return <CanvasFigure label="rotating frame · ω about ŷ" className="w-full sm:w-2/3 mx-auto">
+        <Physics3DCanvas
+            className="aspect-square w-full rounded-lg"
+            initialView={{radius: 16, at: {x: 6, y: 6, z: 8}}}
+            axis
+            ground={{opacity: 0.6}}
+        >
+            <SpinningTriad/>
+        </Physics3DCanvas>
+    </CanvasFigure>;
+};
+
+export default RotatingFrame;

--- a/document/src/components/pages/chapter3/ScrewMotion.tsx
+++ b/document/src/components/pages/chapter3/ScrewMotion.tsx
@@ -1,0 +1,63 @@
+import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import AxisTriad from "../../3d/AxisTriad";
+import {Animation, Color3, IAnimationKey, TransformNode, Vector3} from "@babylonjs/core";
+import {useScene} from "react-babylonjs";
+
+// 트위스트 V = S θ̇: 스크류 축 둘레의 나선 운동. body frame 이 축(수직 ŷ)을 돌면서 동시에 축을 따라
+// 병진해 나선을 그린다 — 순수 회전(각속도)과 순수 병진이 결합된 rigid-body velocity.
+const RADIUS = 4;
+const TURNS = 2;
+const RISE = 8;
+const Y0 = -4;
+const PHI_MAX = TURNS * 2 * Math.PI;
+const TOTAL_FRAMES = 300;
+
+const helixPoint = (phi: number) =>
+    new Vector3(RADIUS * Math.cos(phi), Y0 + RISE * (phi / PHI_MAX), RADIUS * Math.sin(phi));
+
+// 나선 궤적(정적 참조선)
+const HELIX_TRACE = Array.from({length: 121}, (_, i) => helixPoint((i / 120) * PHI_MAX));
+
+const ScrewFrame = () => {
+    const scene = useScene();
+    return <AxisTriad name="screw-body" size={3} onReady={(node: TransformNode) => {
+        const positionKeys: IAnimationKey[] = [];
+        const rotationKeys: IAnimationKey[] = [];
+        const samples = 60;
+        for (let i = 0; i <= samples; i++) {
+            const phi = (i / samples) * PHI_MAX;
+            const frame = (i / samples) * TOTAL_FRAMES;
+            positionKeys.push({frame, value: helixPoint(phi)});
+            rotationKeys.push({frame, value: phi});
+        }
+        const positionAnim = new Animation(
+            "screw-pos", "position", 30,
+            Animation.ANIMATIONTYPE_VECTOR3, Animation.ANIMATIONLOOPMODE_CYCLE,
+        );
+        positionAnim.setKeys(positionKeys);
+        const rotationAnim = new Animation(
+            "screw-rot", "rotation.y", 30,
+            Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_CYCLE,
+        );
+        rotationAnim.setKeys(rotationKeys);
+        node.animations = [positionAnim, rotationAnim];
+        scene?.beginAnimation(node, 0, TOTAL_FRAMES, true);
+    }}/>;
+};
+
+const ScrewMotion = () => {
+    return <CanvasFigure label="screw motion · twist about ŷ" className="w-full sm:w-2/3 mx-auto">
+        <Physics3DCanvas
+            className="aspect-square w-full rounded-lg"
+            initialView={{radius: 20, at: {x: 8, y: 4, z: 10}}}
+            axis
+            ground={{opacity: 0.6}}
+        >
+            <lines name="helix-trace" points={HELIX_TRACE} color={new Color3(0.95, 0.65, 0.2)}/>
+            <ScrewFrame/>
+        </Physics3DCanvas>
+    </CanvasFigure>;
+};
+
+export default ScrewMotion;

--- a/document/src/components/pages/chapter4/PlanarChain3R.tsx
+++ b/document/src/components/pages/chapter4/PlanarChain3R.tsx
@@ -1,0 +1,120 @@
+import {useMemo, useState} from "react";
+import {Circle, Line, Text} from "react-konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap} from "../../../libs/konvaUtils";
+import {useCanvasColors} from "../../../libs/useTheme";
+
+// 3R 평면 개방연쇄의 정방향 기구학. 슬라이더로 관절각 θ1,θ2,θ3 를 돌리면 링크를 순차 누적해
+// end-effector 위치 (x,y) 와 방향 φ 가 실시간 갱신된다.
+const LINKS = [2.5, 2, 1.5];
+const RESOLUTION = 0.05;
+
+// -0.0001 → "-0" 방지: 반올림 후 0 근처는 0 으로 정규화한다.
+const degrees = (rad: number) => {
+    const d = Math.round(rad * 180 / Math.PI);
+    return d === 0 ? 0 : d;
+};
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const PlanarChainScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [theta, setTheta] = useState<[number, number, number]>([0.6, 0.7, 0.5]);
+
+    const {world, phi} = useMemo(() => {
+        let x = 0, y = 0, a = 0;
+        const world = [{x, y}];
+        for (let i = 0; i < LINKS.length; i++) {
+            a += theta[i];
+            x += LINKS[i] * Math.cos(a);
+            y += LINKS[i] * Math.sin(a);
+            world.push({x, y});
+        }
+        return {world, phi: a};
+    }, [theta]);
+
+    const px = world.map((p) => globalToMap(width, height, p.x, p.y, RESOLUTION));
+    const ee = world[world.length - 1];
+
+    const setJoint = (i: number, v: number) =>
+        setTheta((prev) => {
+            const next = [...prev] as [number, number, number];
+            next[i] = v;
+            return next;
+        });
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {px.slice(0, -1).map((p, i) => (
+                    <Line
+                        key={`link-${i}`}
+                        points={[p.x, p.y, px[i + 1].x, px[i + 1].y]}
+                        stroke={colors.accent}
+                        strokeWidth={4}
+                        lineCap="round"
+                    />
+                ))}
+                {px.slice(0, -1).map((p, i) => (
+                    <Circle key={`joint-${i}`} x={p.x} y={p.y} radius={5} fill={colors.surface}
+                            stroke={colors.text} strokeWidth={2}/>
+                ))}
+                <Circle x={px[px.length - 1].x} y={px[px.length - 1].y} radius={7} fill={colors.accent}/>
+                <Text
+                    x={px[px.length - 1].x + 10}
+                    y={px[px.length - 1].y - 6}
+                    text={`(${ee.x.toFixed(2)}, ${ee.y.toFixed(2)})`}
+                    fontSize={13}
+                    fontStyle="bold"
+                    fill={colors.text}
+                />
+            </CoordinateSystem>
+            <div className="w-full flex flex-col gap-1 text-xs text-muted">
+                {[0, 1, 2].map((i) => (
+                    <label key={i} className="flex items-center gap-2">
+                        <span className="w-8 shrink-0">θ{i + 1}</span>
+                        <input
+                            type="range"
+                            min={-Math.PI}
+                            max={Math.PI}
+                            step={0.01}
+                            value={theta[i]}
+                            onChange={(e) => setJoint(i, parseFloat(e.target.value))}
+                            className="w-full accent-[var(--accent)]"
+                            aria-label={`joint angle theta ${i + 1}`}
+                        />
+                        <span className="w-12 shrink-0 text-right tabular-nums">
+                            {degrees(theta[i])}°
+                        </span>
+                    </label>
+                ))}
+                <div className="text-center pt-1">
+                    x = {ee.x.toFixed(2)} · y = {ee.y.toFixed(2)} · φ = {degrees(phi)}°
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const PlanarChain3R = () => {
+    return <CanvasFigure
+        label="3R planar chain · forward kinematics"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<PlanarChainScene width={460} height={460}/>}
+    >
+        <PlanarChainScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default PlanarChain3R;

--- a/document/src/components/pages/chapter4/UrdfRobot.tsx
+++ b/document/src/components/pages/chapter4/UrdfRobot.tsx
@@ -1,0 +1,167 @@
+import Physics3DCanvas from "../../3d/Physics3DCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {Animation, Color3, IAnimationKey, TransformNode, Vector3} from "@babylonjs/core";
+import {useScene} from "react-babylonjs";
+import {ReactNode} from "react";
+import {InlineMath} from "../../math/Tex";
+import XmlCode from "../../XmlCode";
+
+// URDF 가 기술하는 것: link(질량·형상) 들이 joint(타입·축·부모/자식) 로 이어진 트리.
+// 여기선 base → joint → link 를 3단 중첩 부모관계로 세우고 관절을 회전시켜 정방향 기구학을 보인다.
+const LINK_COLORS = [new Color3(0.39, 0.4, 0.95), new Color3(0.13, 0.7, 0.85), new Color3(0.6, 0.4, 0.9)];
+const JOINT_COLOR = new Color3(0.95, 0.65, 0.2);
+
+const oscillation = (property: "rotation.y" | "rotation.z", amplitude: number): Animation => {
+    const anim = new Animation("joint", property, 30, Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_CYCLE);
+    const keys: IAnimationKey[] = [
+        {frame: 0, value: 0},
+        {frame: 60, value: amplitude},
+        {frame: 120, value: 0},
+        {frame: 180, value: -amplitude},
+        {frame: 240, value: 0},
+    ];
+    anim.setKeys(keys);
+    return anim;
+};
+
+interface JointProps {
+    name: string;
+    property: "rotation.y" | "rotation.z";
+    amplitude: number;
+    linkIndex: number;
+    length: number;
+    children?: ReactNode;
+}
+
+// joint(회전 노드) + 그 자식 link(box). link 끝(+Y)에 다음 joint 를 자식으로 매단다.
+const Joint = ({name, property, amplitude, linkIndex, length, children}: JointProps) => {
+    const scene = useScene();
+    return (
+        <transformNode name={name} onCreated={(node: TransformNode) => {
+            node.animations = [oscillation(property, amplitude)];
+            scene?.beginAnimation(node, 0, 240, true);
+        }}>
+            {/* joint 표식 */}
+            <sphere name={`${name}-marker`} diameter={0.9}>
+                <standardMaterial name={`${name}-marker-mat`} diffuseColor={JOINT_COLOR}
+                                  emissiveColor={JOINT_COLOR.scale(0.3)}/>
+            </sphere>
+            {/* link geometry */}
+            <box name={`${name}-link`} width={0.7} height={length} depth={0.7} position={new Vector3(0, length / 2, 0)}>
+                <standardMaterial name={`${name}-link-mat`} diffuseColor={LINK_COLORS[linkIndex]}/>
+            </box>
+            {children}
+        </transformNode>
+    );
+};
+
+const Arm = () => (
+    <Joint name="joint1" property="rotation.y" amplitude={0.6} linkIndex={0} length={3}>
+        <transformNode name="link1-end" position={new Vector3(0, 3, 0)}>
+            <Joint name="joint2" property="rotation.z" amplitude={-0.7} linkIndex={1} length={2.5}>
+                <transformNode name="link2-end" position={new Vector3(0, 2.5, 0)}>
+                    <Joint name="joint3" property="rotation.z" amplitude={0.8} linkIndex={2} length={1.8}>
+                        {/* end-effector */}
+                        <sphere name="ee" diameter={0.7} position={new Vector3(0, 1.8, 0)}>
+                            <standardMaterial name="ee-mat" diffuseColor={new Color3(0.9, 0.25, 0.25)}
+                                              emissiveColor={new Color3(0.4, 0.1, 0.1)}/>
+                        </sphere>
+                    </Joint>
+                </transformNode>
+            </Joint>
+        </transformNode>
+    </Joint>
+);
+
+// 시각화된 3-링크 팔에 대응하는 xacro. property/macro 로 링크를 재사용하고, 각 joint 가
+// parent/child·axis·origin(링크 간 변환)을 명시하는 URDF 트리 구조를 보인다. (\${...} 는 xacro 식)
+const XACRO = `<?xml version="1.0"?>
+<robot name="arm3" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- one place to tune the chain -->
+  <xacro:property name="l1" value="3.0"/>
+  <xacro:property name="l2" value="2.5"/>
+  <xacro:property name="l3" value="1.8"/>
+
+  <!-- reusable link: a bar of length L along +Z -->
+  <xacro:macro name="bar_link" params="name length">
+    <link name="\${name}">
+      <visual>
+        <origin xyz="0 0 \${length/2}"/>
+        <geometry><box size="0.7 0.7 \${length}"/></geometry>
+      </visual>
+      <inertial>
+        <mass value="1.0"/>
+        <inertia ixx="0.1" iyy="0.1" izz="0.1" ixy="0" ixz="0" iyz="0"/>
+      </inertial>
+    </link>
+  </xacro:macro>
+
+  <link name="base_link"/>
+  <xacro:bar_link name="link1" length="\${l1}"/>
+  <xacro:bar_link name="link2" length="\${l2}"/>
+  <xacro:bar_link name="link3" length="\${l3}"/>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>  <child link="link1"/>
+    <axis xyz="0 0 1"/>  <origin xyz="0 0 0"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="2"/>
+  </joint>
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>  <child link="link2"/>
+    <axis xyz="0 1 0"/>  <origin xyz="0 0 \${l1}"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="2"/>
+  </joint>
+  <joint name="joint3" type="revolute">
+    <parent link="link2"/>  <child link="link3"/>
+    <axis xyz="0 1 0"/>  <origin xyz="0 0 \${l2}"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="2"/>
+  </joint>
+</robot>`;
+
+// 코드블록 아래 각주: xacro/URDF 핵심 요소가 무엇을 하는지 매핑한다.
+const NOTES: {tag: string; body: ReactNode}[] = [
+    {tag: "xacro:property", body: <>named constants for the chain's dimensions, referenced as <code>${"{l1}"}</code>.</>},
+    {tag: "xacro:macro", body: <>a parameterized, reusable block — <code>bar_link</code> stamps out all three links from one definition instead of repeating them.</>},
+    {tag: "link", body: <>a rigid body: <code>visual</code> geometry plus <code>inertial</code> mass and inertia.</>},
+    {
+        tag: "joint type=\"revolute\"",
+        body: <>a rotating joint. <code>parent</code>→<code>child</code> builds the tree, <code>axis</code> is
+            the rotation axis, <code>origin</code> is the fixed transform to the parent link (the{" "}
+            <InlineMath math='T_{i-1,i}'/> forward kinematics multiplies), and <code>limit</code> bounds its
+            travel.</>,
+    },
+    {tag: "build", body: <>at build time xacro expands every property and macro into plain URDF.</>},
+];
+
+const UrdfRobot = () => {
+    return <div className="my-4">
+        <div className="flex flex-col lg:flex-row gap-4 lg:items-stretch">
+            <div className="lg:w-1/2 flex">
+                <CanvasFigure label="serial-chain robot · links + joints" className="w-full">
+                    <Physics3DCanvas
+                        className="aspect-square w-full rounded-lg"
+                        initialView={{radius: 18, at: {x: 8, y: 8, z: 10}, to: {x: 0, y: 3, z: 0}}}
+                        axis
+                        ground={{opacity: 0.6}}
+                    >
+                        <Arm/>
+                    </Physics3DCanvas>
+                </CanvasFigure>
+            </div>
+            <div className="lg:w-1/2 min-w-0 flex flex-col items-center gap-1 p-3">
+                <XmlCode code={XACRO} className="w-full !my-0 max-h-[440px] overflow-auto text-xs"/>
+                <span className="text-xs text-muted">arm3.urdf.xacro</span>
+            </div>
+        </div>
+        <dl className="mt-3 text-sm text-muted border border-border rounded-lg p-4 space-y-1.5">
+            {NOTES.map(({tag, body}) => (
+                <div key={tag} className="flex flex-col sm:flex-row sm:gap-2">
+                    <dt className="shrink-0"><code>{tag}</code></dt>
+                    <dd>{body}</dd>
+                </div>
+            ))}
+        </dl>
+    </div>;
+};
+
+export default UrdfRobot;

--- a/document/src/index.css
+++ b/document/src/index.css
@@ -19,6 +19,13 @@
     --border: #e2e8f0;
     --code-bg: #f6f8fa;
     --code-text: #1f2937;
+    /* XML/xacro syntax highlight tokens (light) */
+    --tok-comment: #6a737d;
+    --tok-tag: #116329;
+    --tok-attr: #6f42c1;
+    --tok-string: #0a3069;
+    --tok-expr: #953800;
+    --tok-punct: #57606a;
     --shadow: 0 1px 3px rgba(15, 23, 42, .08), 0 8px 24px rgba(15, 23, 42, .05);
     --radius: 14px;
     --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
@@ -42,6 +49,13 @@
     --border: #24304a;
     --code-bg: #0e1526;
     --code-text: #dbe4f3;
+    /* XML/xacro syntax highlight tokens (dark) */
+    --tok-comment: #8b949e;
+    --tok-tag: #7ee787;
+    --tok-attr: #d2a8ff;
+    --tok-string: #a5d6ff;
+    --tok-expr: #ffa657;
+    --tok-punct: #8b949e;
     --shadow: 0 1px 3px rgba(0, 0, 0, .4), 0 12px 30px rgba(0, 0, 0, .35);
 }
 
@@ -58,6 +72,12 @@
         --border: #24304a;
         --code-bg: #0e1526;
         --code-text: #dbe4f3;
+        --tok-comment: #8b949e;
+        --tok-tag: #7ee787;
+        --tok-attr: #d2a8ff;
+        --tok-string: #a5d6ff;
+        --tok-expr: #ffa657;
+        --tok-punct: #8b949e;
         --shadow: 0 1px 3px rgba(0, 0, 0, .4), 0 12px 30px rgba(0, 0, 0, .35);
     }
 }

--- a/document/src/pages/chapters/Chapter3.tsx
+++ b/document/src/pages/chapters/Chapter3.tsx
@@ -1,5 +1,9 @@
 import {BlockMath, InlineMath} from "../../components/math/Tex";
 import {resolvePath} from "../../libs/url";
+import RotatingFrame from "../../components/pages/chapter3/RotatingFrame";
+import ExponentialRotation from "../../components/pages/chapter3/ExponentialRotation";
+import HomogeneousTransform from "../../components/pages/chapter3/HomogeneousTransform";
+import ScrewMotion from "../../components/pages/chapter3/ScrewMotion";
 
 const Chapter3 = () => {
     return (
@@ -29,6 +33,13 @@ const Chapter3 = () => {
                 alt="Angular velocity of a rotating frame"
                 loading="lazy"
             />
+            <p>
+                The body frame <InlineMath math='\{b\}'/> spins relative to the fixed frame{" "}
+                <InlineMath math='\{s\}'/> at angular velocity <InlineMath math='\omega'/> — a direction{" "}
+                <InlineMath math='\hat{\omega}'/> (here the vertical axis) and a rate{" "}
+                <InlineMath math='\dot{\theta}'/>. Drag to orbit and watch the moving axes.
+            </p>
+            <RotatingFrame/>
             <p><strong>Angular velocity</strong> :</p>
             <BlockMath math='\omega = \hat{\omega}\dot{\theta}'/>
             <p><strong>Linear velocity</strong> :</p>
@@ -70,6 +81,13 @@ const Chapter3 = () => {
                 serves as the three-parameter exponential coordinate representation of the rotation.
             </p>
             <BlockMath math='R = e^{[\hat{\omega}]\theta}'/>
+            <p>
+                Drag the slider to sweep the angle <InlineMath math='\theta'/> about a fixed axis{" "}
+                <InlineMath math='\hat{\omega}'/> (orange). The body frame traces the one-parameter family of
+                rotations <InlineMath math='e^{[\hat{\omega}]\theta}'/>; at <InlineMath math='\theta = 0'/> it
+                coincides with the fixed frame.
+            </p>
+            <ExponentialRotation/>
 
             <h2>Homogeneous Transformation</h2>
             <p><strong>Definition</strong> : The special Euclidean group <InlineMath math='SE(3)'/>, also known as
@@ -83,6 +101,12 @@ const Chapter3 = () => {
                 <InlineMath math='p'/> its origin, packaged into one matrix so a single object represents both
                 position and orientation. An element is sometimes written <InlineMath math='T = (R, p)'/>.
             </p>
+            <p>
+                Below, the body frame sits at position <InlineMath math='p'/> (violet vector from the origin)
+                with orientation <InlineMath math='R'/> — a single <InlineMath math='T'/> capturing both. Drag to
+                orbit.
+            </p>
+            <HomogeneousTransform/>
             <p><strong>Inverse</strong> : the inverse of a transformation is itself a transformation,</p>
             <BlockMath math={`T^{-1} = \\begin{bmatrix} R^T & -R^T p \\\\ 0 & 1 \\end{bmatrix}`}/>
             <p><strong>Properties</strong> : closure, associative, not commutative, and identity{" "}
@@ -109,6 +133,12 @@ const Chapter3 = () => {
                 twist is the scaled screw axis <InlineMath math='\mathcal{V} = \mathcal{S}\dot{\theta}'/>, the
                 geometric picture behind the exponential coordinates of rigid-body motion.
             </p>
+            <p>
+                A screw axis combines rotation about a line with translation along it. The body frame below turns
+                about the vertical axis while advancing along it, tracing the helix (orange) that a constant twist
+                produces.
+            </p>
+            <ScrewMotion/>
         </>
     )
 }

--- a/document/src/pages/chapters/Chapter4.tsx
+++ b/document/src/pages/chapters/Chapter4.tsx
@@ -1,4 +1,6 @@
 import {BlockMath, InlineMath} from "../../components/math/Tex";
+import PlanarChain3R from "../../components/pages/chapter4/PlanarChain3R";
+import UrdfRobot from "../../components/pages/chapter4/UrdfRobot";
 
 const Chapter4 = () => {
     return (
@@ -19,6 +21,12 @@ const Chapter4 = () => {
                 y = L_1\\sin\\theta_1 + L_2\\sin(\\theta_1+\\theta_2) + L_3\\sin(\\theta_1+\\theta_2+\\theta_3) \\\\[4pt]
                 \\phi = \\theta_1 + \\theta_2 + \\theta_3
                 \\end{gathered}`}/>
+            <p>
+                Drag the three joint sliders and watch the end-effector <InlineMath math='(x, y)'/> and
+                orientation <InlineMath math='\phi'/> follow directly from the joint values — this is exactly what
+                forward kinematics computes.
+            </p>
+            <PlanarChain3R/>
             <p>
                 A more systematic route attaches a frame to each link and multiplies the successive homogeneous
                 transformations, <InlineMath math='T_{04} = T_{01} T_{12} T_{23} T_{34}'/>. Two standard
@@ -83,6 +91,12 @@ const Chapter4 = () => {
                 axes and the home configuration <InlineMath math='M'/> — and the inertial data that later chapters
                 use for dynamics.
             </p>
+            <p>
+                The robot below is exactly such a tree: three <strong>links</strong> (colored bars) joined by
+                three <strong>joints</strong> (orange), each joint rotating its subtree — the same nested
+                parent-child structure a URDF encodes.
+            </p>
+            <UrdfRobot/>
         </>
     )
 }


### PR DESCRIPTION
## Summary

Bring chapter-2-style visual learning to **Chapter 3 (Rigid-Body Motions)** and **Chapter 4 (Forward Kinematics)** — a figure per key concept, reusing the existing `Physics3DCanvas` / `CoordinateCanvas` / `CanvasFigure` scaffolding.

### Chapter 3
- **Rotating frame** — angular velocity `ω = ω̂θ̇`, animated body frame
- **Exponential coordinates** — interactive angle slider driving `R = e^[ω̂]θ` about a fixed axis
- **SE(3) `T = (R, p)`** — a body frame offset by `p` with orientation `R`
- **Screw motion** — twist tracing a helix (animated)

### Chapter 4
- **3R planar chain** — Konva 2D with `θ₁·θ₂·θ₃` sliders; end-effector `(x, y, φ)` updates live
- **Serial-chain robot** — links + joints as a nested parent-child tree (animated), shown next to a **color-highlighted xacro** block with annotated URDF/xacro element notes

### Shared additions
- `components/3d/AxisTriad.tsx` — reusable body-frame axis triad
- `components/XmlCode.tsx` — dependency-free XML/xacro syntax highlighter with theme-aware token colors (added to `index.css`)

### Docs
- New **`CLAUDE.md`** and a README **"Authoring chapters"** section recording the convention that each chapter should teach visually; refreshed the chapter table and project structure.

## Verification
- Drove both chapters in the dev server (`?chapter=3`, `?chapter=4`): all six figures render, animate, and respond to sliders / modal zoom with no console errors
- Confirmed readability of the syntax-highlighted xacro and figures in both light and dark themes
- `yarn build` passes; `tsc --noEmit` reports no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)