### PR TITLE
feat(chapter3): clearer, more intuitive rigid-body-motion figures

### DIFF
--- a/document/src/components/3d/Label3D.tsx
+++ b/document/src/components/3d/Label3D.tsx
@@ -1,0 +1,78 @@
+import {DynamicTexture, Mesh, MeshBuilder, StandardMaterial, Vector3} from "@babylonjs/core";
+import {useScene} from "react-babylonjs";
+import {useEffect, useRef} from "react";
+
+// 3D 씬 안에 텍스트 라벨을 띄운다. DynamicTexture 를 빌보드 평면에 그려 카메라를 항상 바라보게 한다.
+// (@babylonjs/gui 의존성 없이 core 만으로 구현.) 어두운 외곽선을 둘러 라이트/다크 배경 모두 가독.
+// text/color 가 바뀌면 텍스처만 다시 그린다 (슬라이더로 값이 갱신되는 라벨 대응).
+interface Label3DProps {
+    text: string;
+    color: string;
+    position: Vector3;
+    size?: number;
+    onReady?: (mesh: Mesh) => void;
+}
+
+const TEX_W = 384;
+const TEX_H = 128;
+
+const Label3D = ({text, color, position, size = 1.3, onReady}: Label3DProps) => {
+    const scene = useScene();
+    const dtRef = useRef<DynamicTexture | null>(null);
+
+    const draw = (t: string, c: string) => {
+        const dt = dtRef.current;
+        if (!dt) return;
+        // Babylon 의 ICanvasRenderingContext 타입엔 textAlign 등이 없지만 브라우저에선 실제 2D 컨텍스트다.
+        const ctx = dt.getContext() as unknown as CanvasRenderingContext2D;
+        ctx.clearRect(0, 0, TEX_W, TEX_H);
+        ctx.font = "bold 64px sans-serif";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.lineJoin = "round";
+        ctx.lineWidth = 10;
+        ctx.strokeStyle = "rgba(0,0,0,0.6)";
+        ctx.strokeText(t, TEX_W / 2, TEX_H / 2);
+        ctx.fillStyle = c;
+        ctx.fillText(t, TEX_W / 2, TEX_H / 2);
+        dt.update();
+    };
+
+    useEffect(() => {
+        if (!scene) return;
+        const dt = new DynamicTexture("label", {width: TEX_W, height: TEX_H}, scene, false);
+        dt.hasAlpha = true;
+        dtRef.current = dt;
+        draw(text, color);
+
+        const plane = MeshBuilder.CreatePlane("label-plane", {width: size * (TEX_W / TEX_H), height: size}, scene);
+        const mat = new StandardMaterial("label-mat", scene);
+        mat.diffuseTexture = dt;
+        mat.emissiveTexture = dt;
+        mat.useAlphaFromDiffuseTexture = true;
+        mat.disableLighting = true;
+        mat.backFaceCulling = false;
+        plane.material = mat;
+        plane.billboardMode = Mesh.BILLBOARDMODE_ALL;
+        plane.position = position;
+        plane.isPickable = false;
+        onReady?.(plane);
+        return () => {
+            plane.dispose();
+            mat.dispose();
+            dt.dispose();
+            dtRef.current = null;
+        };
+        // 최초 1회 생성. text/color 변경은 아래 effect 가 다시 그린다.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scene]);
+
+    useEffect(() => {
+        draw(text, color);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [text, color]);
+
+    return null;
+};
+
+export default Label3D;

--- a/document/src/components/pages/chapter3/ExponentialRotation.tsx
+++ b/document/src/components/pages/chapter3/ExponentialRotation.tsx
@@ -2,18 +2,31 @@ import {useEffect, useMemo, useRef, useState} from "react";
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
 import CanvasFigure from "../../CanvasFigure";
 import AxisTriad from "../../3d/AxisTriad";
+import Label3D from "../../3d/Label3D";
 import {Color3, Quaternion, TransformNode, Vector3} from "@babylonjs/core";
 
-// 지수 좌표 R = e^[ω̂]θ 의 기하: 고정된 회전축 ω̂(주황 선) 둘레로 body frame 이 각 θ 만큼 돈다.
+// 지수 좌표 R = e^[ω̂]θ 의 기하: 고정된 회전축 ω̂(주황 막대) 둘레로 body frame 이 각 θ 만큼 돈다.
 // 슬라이더로 θ 를 직접 돌려 축-각 파라미터가 회전을 어떻게 만드는지 본다.
-const AXIS = new Vector3(0.35, 1, 0.3).normalize();
+// y 축과 확실히 구분되도록 뚜렷하게 기울인다.
+const AXIS = new Vector3(0.55, 0.7, 0.45).normalize();
+const AXIS_COLOR = new Color3(0.95, 0.65, 0.2);
+// 기본 +Y 실린더를 ω̂ 방향으로 회전시키는 쿼터니언.
+const AXIS_QUAT = Quaternion.RotationAxis(
+    Vector3.Cross(Vector3.Up(), AXIS).normalize(),
+    Math.acos(Vector3.Dot(Vector3.Up(), AXIS)),
+);
 
-const RotationAxisLine = () => (
-    <lines
-        name="omega-axis"
-        points={[AXIS.scale(-9), AXIS.scale(9)]}
-        color={new Color3(0.95, 0.65, 0.2)}
-    />
+// 회전축을 얇은 선 대신 굵은 막대 + 화살촉으로 그려 한눈에 보이게 한다.
+const RotationAxisRod = () => (
+    <>
+        <cylinder name="omega-rod" height={17} diameter={0.16} tessellation={16} rotationQuaternion={AXIS_QUAT}>
+            <standardMaterial name="omega-rod-mat" diffuseColor={AXIS_COLOR} emissiveColor={AXIS_COLOR.scale(0.4)}/>
+        </cylinder>
+        <cylinder name="omega-rod-tip" height={1} diameterTop={0} diameterBottom={0.5} tessellation={16}
+                  rotationQuaternion={AXIS_QUAT} position={AXIS.scale(8.5)}>
+            <standardMaterial name="omega-rod-tip-mat" diffuseColor={AXIS_COLOR} emissiveColor={AXIS_COLOR.scale(0.4)}/>
+        </cylinder>
+    </>
 );
 
 interface SceneProps {
@@ -33,11 +46,14 @@ const ExpRotationScene = ({canvasClassName}: SceneProps) => {
         <div className="flex flex-col gap-2 w-full">
             <Physics3DCanvas
                 className={canvasClassName}
-                initialView={{radius: 15, at: {x: 6, y: 6, z: 8}}}
+                initialView={{radius: 24, at: {x: 9, y: 8, z: 11}, to: {x: 0, y: 1, z: 0}}}
                 axis
                 ground={{opacity: 0.6}}
             >
-                <RotationAxisLine/>
+                <RotationAxisRod/>
+                <Label3D text="ω̂" color="#f2a63a" position={AXIS.scale(9.4)} size={1.7}/>
+                <Label3D text={`θ = ${(theta * 180 / Math.PI).toFixed(0)}°`} color="#e8ecf7"
+                         position={new Vector3(0, 8, 0)} size={2}/>
                 <AxisTriad name="exp-body" size={5} onReady={(node: TransformNode) => {
                     nodeRef.current = node;
                     node.rotationQuaternion = pose;

--- a/document/src/components/pages/chapter3/HomogeneousTransform.tsx
+++ b/document/src/components/pages/chapter3/HomogeneousTransform.tsx
@@ -1,32 +1,81 @@
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
 import CanvasFigure from "../../CanvasFigure";
 import AxisTriad from "../../3d/AxisTriad";
-import {Color3, Quaternion, TransformNode, Vector3} from "@babylonjs/core";
+import Label3D from "../../3d/Label3D";
+import {Animation, Color3, IAnimationKey, LinesMesh, Mesh, MeshBuilder, StandardMaterial, TransformNode, Vector3} from "@babylonjs/core";
+import {useRef} from "react";
+import {useScene} from "react-babylonjs";
 
-// SE(3) 원소 T = (R, p): 고정 space frame {s}(원점) 대비 body frame {b} 가 방향 R 로 돌아가고
-// 위치 p 만큼 떨어져 있다. 이동벡터 p 를 선으로, 끝점을 구로 표시한다. 드래그로 궤도 회전.
-const P = new Vector3(5, 3, -3);
-const R = Quaternion.RotationAxis(new Vector3(0.3, 1, 0.4).normalize(), 0.9);
+// SE(3) 원소 T = (R, p): body frame {b} 가 방향 R 로 돌면서 위치 p 로 이동하는 강체 운동.
+// 프레임이 매 프레임 (R,p) 를 지나가고, 원점→p 이동벡터가 이를 따라간다.
+const P_COLOR = new Color3(0.6, 0.55, 0.95);
+const TOTAL_FRAMES = 300;
+
+// 이동 경로의 양 끝점 (position 애니메이션 왕복).
+const P_A = new Vector3(4.5, 2, -3);
+const P_B = new Vector3(-2.5, 5, 2.5);
+
+const MovingFrame = () => {
+    const scene = useScene();
+    const markerRef = useRef<Mesh | null>(null);
+    const labelRef = useRef<Mesh | null>(null);
+
+    return <>
+        {/* body frame 원점 표식 (프레임과 함께 움직인다) */}
+        <sphere name="p-marker" diameter={0.55} onCreated={(mesh: Mesh) => {
+            const mat = new StandardMaterial("p-marker-mat", mesh.getScene());
+            mat.diffuseColor = P_COLOR;
+            mat.emissiveColor = P_COLOR.scale(0.4);
+            mesh.material = mat;
+            markerRef.current = mesh;
+        }}/>
+        <Label3D text="p" color="#a99cf5" position={P_A} size={1.5} onReady={(m) => {labelRef.current = m;}}/>
+        <AxisTriad name="se3-body" size={3.5} onReady={(node: TransformNode) => {
+            if (!scene) return;
+            const positionAnim = new Animation(
+                "se3-pos", "position", 30,
+                Animation.ANIMATIONTYPE_VECTOR3, Animation.ANIMATIONLOOPMODE_CYCLE,
+            );
+            const positionKeys: IAnimationKey[] = [
+                {frame: 0, value: P_A},
+                {frame: TOTAL_FRAMES / 2, value: P_B},
+                {frame: TOTAL_FRAMES, value: P_A},
+            ];
+            positionAnim.setKeys(positionKeys);
+            const rotationAnim = new Animation(
+                "se3-rot", "rotation.y", 30,
+                Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_CYCLE,
+            );
+            rotationAnim.setKeys([
+                {frame: 0, value: 0},
+                {frame: TOTAL_FRAMES, value: 2 * Math.PI},
+            ]);
+            node.animations = [positionAnim, rotationAnim];
+            scene.beginAnimation(node, 0, TOTAL_FRAMES, true);
+
+            // 원점→p 이동벡터. updatable 로 만들어 매 프레임 끝점을 프레임 위치에 맞춘다.
+            let line: LinesMesh = MeshBuilder.CreateLines(
+                "p-vector", {points: [Vector3.Zero(), node.position], updatable: true}, scene);
+            line.color = P_COLOR;
+            scene.onBeforeRenderObservable.add(() => {
+                line = MeshBuilder.CreateLines(
+                    "p-vector", {points: [Vector3.Zero(), node.position], instance: line}, scene);
+                if (markerRef.current) markerRef.current.position = node.position;
+                if (labelRef.current) labelRef.current.position = node.position.add(new Vector3(0, 1.1, 0));
+            });
+        }}/>
+    </>;
+};
 
 const HomogeneousTransform = () => {
     return <CanvasFigure label="SE(3) · T = (R, p)" className="w-full sm:w-2/3 mx-auto">
         <Physics3DCanvas
             className="aspect-square w-full rounded-lg"
-            initialView={{radius: 16, at: {x: 7, y: 6, z: 9}}}
+            initialView={{radius: 18, at: {x: 8, y: 7, z: 10}, to: {x: 0, y: 2, z: 0}}}
             axis
             ground={{opacity: 0.6}}
         >
-            {/* 원점에서 p 로 향하는 이동벡터 */}
-            <lines name="p-vector" points={[Vector3.Zero(), P]} color={new Color3(0.6, 0.55, 0.95)}/>
-            <sphere name="p-marker" diameter={0.5} position={P}>
-                <standardMaterial name="p-marker-mat" diffuseColor={new Color3(0.6, 0.55, 0.95)}
-                                  emissiveColor={new Color3(0.3, 0.28, 0.5)}/>
-            </sphere>
-            {/* p 에 놓인 body frame, 방향 R */}
-            <AxisTriad name="se3-body" size={4} onReady={(node: TransformNode) => {
-                node.position = P;
-                node.rotationQuaternion = R;
-            }}/>
+            <MovingFrame/>
         </Physics3DCanvas>
     </CanvasFigure>;
 };

--- a/document/src/components/pages/chapter3/RotatingFrame.tsx
+++ b/document/src/components/pages/chapter3/RotatingFrame.tsx
@@ -1,35 +1,115 @@
 import Physics3DCanvas from "../../3d/Physics3DCanvas";
 import CanvasFigure from "../../CanvasFigure";
 import AxisTriad from "../../3d/AxisTriad";
-import {Animation, TransformNode} from "@babylonjs/core";
+import Label3D from "../../3d/Label3D";
+import {Animation, Color3, Mesh, Quaternion, TransformNode, Vector3} from "@babylonjs/core";
+import {useRef} from "react";
 import {useScene} from "react-babylonjs";
 
-// body frame {b} 가 고정 space frame {s} 대비 각속도 ω 로 연속 회전한다 (ω = ω̂ θ̇, 여기선 ω̂ = ŷ).
-const SpinningTriad = () => {
+const OMEGA_COLOR = new Color3(0.95, 0.65, 0.2);
+const VEL_COLOR = new Color3(0.13, 0.83, 0.93);
+const SIZE = 4;
+// 방향만 쓰므로 크기는 1 로 둔다 (v = ω × r 의 방향 = 접선).
+const OMEGA = new Vector3(0, 1, 0);
+
+// 회전축이자 각속도 벡터 ω 를 +Y 를 따라 굵은 화살표로 그린다.
+const OmegaArrow = () => (
+    <>
+        <cylinder name="omega-shaft" height={5} diameter={0.18} tessellation={16} position={new Vector3(0, 2.5, 0)}>
+            <standardMaterial name="omega-shaft-mat" diffuseColor={OMEGA_COLOR} emissiveColor={OMEGA_COLOR.scale(0.4)}/>
+        </cylinder>
+        <cylinder name="omega-tip" height={1} diameterTop={0} diameterBottom={0.5} tessellation={16}
+                  position={new Vector3(0, 5.5, 0)}>
+            <standardMaterial name="omega-tip-mat" diffuseColor={OMEGA_COLOR} emissiveColor={OMEGA_COLOR.scale(0.4)}/>
+        </cylinder>
+    </>
+);
+
+// body 축 끝점이 그리는 원 (속도가 접선임을 보이기 위한 경로).
+const CIRCLE = Array.from({length: 65}, (_, i) => {
+    const a = (i / 64) * 2 * Math.PI;
+    return new Vector3(SIZE * Math.cos(a), 0, SIZE * Math.sin(a));
+});
+
+// 고정 길이 속도 화살표(+Y 기준). 매 프레임 위치/방향만 갱신한다.
+const VelocityArrow = ({name, onReady}: {name: string; onReady: (n: TransformNode) => void}) => (
+    <transformNode name={name} onCreated={(n: TransformNode) => onReady(n)}>
+        <cylinder name={`${name}-shaft`} height={1.5} diameter={0.14} tessellation={16} position={new Vector3(0, 0.75, 0)}>
+            <standardMaterial name={`${name}-shaft-mat`} diffuseColor={VEL_COLOR} emissiveColor={VEL_COLOR.scale(0.4)}/>
+        </cylinder>
+        <cylinder name={`${name}-tip`} height={0.45} diameterTop={0} diameterBottom={0.38} tessellation={16}
+                  position={new Vector3(0, 1.7, 0)}>
+            <standardMaterial name={`${name}-tip-mat`} diffuseColor={VEL_COLOR} emissiveColor={VEL_COLOR.scale(0.4)}/>
+        </cylinder>
+    </transformNode>
+);
+
+// 화살표(+Y)를 위치 at 에 놓고 방향 v 를 향하게 회전. v 가 0 이면 숨긴다(축 위 점은 안 움직임).
+const orientArrow = (node: TransformNode | null, at: Vector3, v: Vector3) => {
+    if (!node) return;
+    const len = v.length();
+    if (len < 1e-3) {
+        node.setEnabled(false);
+        return;
+    }
+    node.setEnabled(true);
+    node.position = at;
+    const d = v.scale(1 / len);
+    const axis = Vector3.Cross(Vector3.Up(), d);
+    const s = axis.length();
+    node.rotationQuaternion = s < 1e-6
+        ? (d.y >= 0 ? Quaternion.Identity() : Quaternion.RotationAxis(Vector3.Forward(), Math.PI))
+        : Quaternion.RotationAxis(axis.scale(1 / s), Math.acos(Math.min(1, Math.max(-1, Vector3.Dot(Vector3.Up(), d)))));
+};
+
+// 각속도의 핵심 직관: body 의 각 점 속도는 v = ω × r 로, 원 궤도의 접선이다.
+// 회전하는 body 프레임의 x̂·ẑ 축 끝에 속도 화살표를 붙이고, 축(ω) 위의 ŷ 끝은 속도가 0 임을 대비한다.
+const AngularVelocityScene = () => {
     const scene = useScene();
-    return <AxisTriad name="rotating-body" size={5} onReady={(node: TransformNode) => {
-        const animation = new Animation(
-            "spin", "rotation.y", 30,
-            Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_CYCLE,
-        );
-        animation.setKeys([
-            {frame: 0, value: 0},
-            {frame: 240, value: 2 * Math.PI},
-        ]);
-        node.animations = [animation];
-        scene?.beginAnimation(node, 0, 240, true);
-    }}/>;
+    const velXRef = useRef<TransformNode | null>(null);
+    const velZRef = useRef<TransformNode | null>(null);
+    const vLabelRef = useRef<Mesh | null>(null);
+
+    return <>
+        <OmegaArrow/>
+        <lines name="tip-circle" points={CIRCLE} color={new Color3(0.4, 0.5, 0.62)}/>
+        <VelocityArrow name="vel-x" onReady={(n) => {velXRef.current = n;}}/>
+        <VelocityArrow name="vel-z" onReady={(n) => {velZRef.current = n;}}/>
+        <Label3D text="ω" color="#f2a63a" position={new Vector3(0.7, 6.2, 0)} size={1.6}/>
+        <Label3D text="v = ω × r" color="#3ad4ee" position={new Vector3(SIZE + 0.5, 1.6, 0)} size={1.7}
+                 onReady={(m) => {vLabelRef.current = m;}}/>
+        <AxisTriad name="rotating-body" size={SIZE} onReady={(node: TransformNode) => {
+            const animation = new Animation(
+                "spin", "rotation.y", 30,
+                Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_CYCLE,
+            );
+            animation.setKeys([{frame: 0, value: 0}, {frame: 300, value: 2 * Math.PI}]);
+            node.animations = [animation];
+            scene?.beginAnimation(node, 0, 300, true);
+
+            scene?.onBeforeRenderObservable.add(() => {
+                node.computeWorldMatrix(true);
+                const wm = node.getWorldMatrix();
+                const tipX = Vector3.TransformCoordinates(new Vector3(SIZE, 0, 0), wm);
+                const tipZ = Vector3.TransformCoordinates(new Vector3(0, 0, SIZE), wm);
+                orientArrow(velXRef.current, tipX, Vector3.Cross(OMEGA, tipX));
+                orientArrow(velZRef.current, tipZ, Vector3.Cross(OMEGA, tipZ));
+                // 라벨은 x̂ 끝 속도 화살표를 따라다닌다.
+                if (vLabelRef.current) vLabelRef.current.position = tipX.add(new Vector3(0, 1.6, 0));
+            });
+        }}/>
+    </>;
 };
 
 const RotatingFrame = () => {
-    return <CanvasFigure label="rotating frame · ω about ŷ" className="w-full sm:w-2/3 mx-auto">
+    return <CanvasFigure label="angular velocity · v = ω × r at each point" className="w-full sm:w-2/3 mx-auto">
         <Physics3DCanvas
             className="aspect-square w-full rounded-lg"
-            initialView={{radius: 16, at: {x: 6, y: 6, z: 8}}}
+            initialView={{radius: 24, at: {x: 9, y: 8, z: 11}, to: {x: 0, y: 2, z: 0}}}
             axis
             ground={{opacity: 0.6}}
         >
-            <SpinningTriad/>
+            <AngularVelocityScene/>
         </Physics3DCanvas>
     </CanvasFigure>;
 };

--- a/document/src/pages/chapters/Chapter3.tsx
+++ b/document/src/pages/chapters/Chapter3.tsx
@@ -34,10 +34,13 @@ const Chapter3 = () => {
                 loading="lazy"
             />
             <p>
-                The body frame <InlineMath math='\{b\}'/> spins relative to the fixed frame{" "}
-                <InlineMath math='\{s\}'/> at angular velocity <InlineMath math='\omega'/> — a direction{" "}
-                <InlineMath math='\hat{\omega}'/> (here the vertical axis) and a rate{" "}
-                <InlineMath math='\dot{\theta}'/>. Drag to orbit and watch the moving axes.
+                Angular velocity <InlineMath math='\omega'/> (orange) is a vector: its direction is the rotation
+                axis and its length the rate <InlineMath math='\dot{\theta}'/>. Every point of the body then moves
+                with velocity <InlineMath math='v = \omega \times r'/> — always <strong>tangent</strong> to the
+                circle it traces (cyan arrows at the axis tips). A point lying on the axis itself, like the{" "}
+                <InlineMath math='\hat{y}'/> tip along <InlineMath math='\omega'/>, has{" "}
+                <InlineMath math='\omega \times r = 0'/> and stays put — which is why the linear velocities below
+                are <InlineMath math='\dot{\hat{x}} = \omega \times \hat{x}'/> and so on.
             </p>
             <RotatingFrame/>
             <p><strong>Angular velocity</strong> :</p>
@@ -102,9 +105,9 @@ const Chapter3 = () => {
                 position and orientation. An element is sometimes written <InlineMath math='T = (R, p)'/>.
             </p>
             <p>
-                Below, the body frame sits at position <InlineMath math='p'/> (violet vector from the origin)
-                with orientation <InlineMath math='R'/> — a single <InlineMath math='T'/> capturing both. Drag to
-                orbit.
+                Below, the body frame moves as a rigid body: at every instant it has a position{" "}
+                <InlineMath math='p'/> (violet vector from the origin) and an orientation <InlineMath math='R'/> —
+                a single <InlineMath math='T'/> capturing both. Drag to orbit.
             </p>
             <HomogeneousTransform/>
             <p><strong>Inverse</strong> : the inverse of a transformation is itself a transformation,</p>


### PR DESCRIPTION
## Summary

Polish the Chapter 3 (Rigid-Body Motions) 3D figures so they *explain* the concept rather than just spin, based on review feedback.

### Angular velocities
- Redesigned so it reads as angular velocity, not "just spinning": the body-axis tips carry **`v = ω × r`** tangent velocity arrows, with a traced path circle. The on-axis `ŷ` tip has `ω × r = 0` and stays put — directly motivating the `ẋ = ω × x̂` equations below it.
- Added in-canvas **`ω`** and **`v = ω × r`** labels; zoomed the camera out.

### Exponential coordinates
- Zoomed out the default view.
- Draw the rotation axis `ω̂` as a **bold, clearly tilted rod** (was a thin, hard-to-see line) with an **`ω̂`** label.
- Show the current rotation angle **`θ` as live canvas text** synced to the slider.

### Homogeneous transformation
- Now **animated** as a moving rigid body, with the **`p` vector following** the frame and a **`p`** label.

### Shared addition
- `components/3d/Label3D.tsx` — a dependency-free billboard text label (Babylon `DynamicTexture`, no `@babylonjs/gui`) with a dark outline so it reads in both light and dark themes; supports live text updates.

## Verification
- Drove `?chapter=3` in the dev server: all three figures render, animate, and respond to sliders with no console errors
- Confirmed label legibility and figure colors in both light and dark themes
- `yarn build` passes; `tsc --noEmit` reports no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)