### PR TITLE
feat(chapter4): copy + click-to-expand for the xacro code block

### DIFF
--- a/document/src/components/CodeFigure.tsx
+++ b/document/src/components/CodeFigure.tsx
@@ -1,0 +1,88 @@
+import {useEffect, useState} from "react";
+import cn from "../libs/cn";
+import Modal from "./Modal";
+import XmlCode from "./XmlCode";
+
+const ZoomIcon = () => (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="11" cy="11" r="7"/>
+        <path d="m21 21-4.3-4.3M11 8v6M8 11h6"/>
+    </svg>
+);
+
+const CopyIcon = () => (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <path d="M5 15V5a2 2 0 0 1 2-2h10"/>
+    </svg>
+);
+
+const CheckIcon = () => (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M20 6 9 17l-5-5"/>
+    </svg>
+);
+
+const CopyButton = ({code}: {code: string}) => {
+    const [copied, setCopied] = useState(false);
+    // 복사 확인 상태를 잠시 뒤 되돌린다. 언마운트 시 타이머 정리.
+    useEffect(() => {
+        if (!copied) return;
+        const id = window.setTimeout(() => setCopied(false), 1600);
+        return () => window.clearTimeout(id);
+    }, [copied]);
+    const copy = async () => {
+        try {
+            await navigator.clipboard.writeText(code);
+            setCopied(true);
+        } catch {
+            // 클립보드 접근 불가(비보안 컨텍스트 등)면 조용히 무시한다.
+        }
+    };
+    return (
+        <button type="button" className={cn("code-fig-btn", copied && "is-copied")} onClick={copy}
+                aria-label={copied ? "Copied" : "Copy code"}>
+            {copied ? <CheckIcon/> : <CopyIcon/>}
+        </button>
+    );
+};
+
+interface CodeFigureProps {
+    code: string;
+    label: string;
+    className?: string;
+    // 인라인 코드블록 스타일(스크롤 높이 등). 모달 안에서는 무시된다.
+    codeClassName?: string;
+}
+
+const CodeFigure = ({code, label, className, codeClassName}: CodeFigureProps) => {
+    const [open, setOpen] = useState(false);
+    return (
+        <div className={cn("flex flex-col items-center gap-1 p-3", className)}>
+            <div className="relative group w-full">
+                <XmlCode code={code} className={cn("w-full !my-0", codeClassName)}/>
+                <div className="code-fig-tools">
+                    <CopyButton code={code}/>
+                    <button type="button" className="code-fig-btn" onClick={() => setOpen(true)}
+                            aria-label={`Expand ${label}`} style={{cursor: "zoom-in"}}>
+                        <ZoomIcon/>
+                    </button>
+                </div>
+            </div>
+            <span className="text-xs text-muted">{label}</span>
+            <Modal open={open} onClose={() => setOpen(false)} title={label}>
+                <div className="relative group w-full">
+                    <XmlCode code={code} className="w-full !my-0 text-sm"/>
+                    <div className="code-fig-tools">
+                        <CopyButton code={code}/>
+                    </div>
+                </div>
+            </Modal>
+        </div>
+    );
+};
+
+export default CodeFigure;

--- a/document/src/components/pages/chapter4/UrdfRobot.tsx
+++ b/document/src/components/pages/chapter4/UrdfRobot.tsx
@@ -4,7 +4,7 @@ import {Animation, Color3, IAnimationKey, TransformNode, Vector3} from "@babylon
 import {useScene} from "react-babylonjs";
 import {ReactNode} from "react";
 import {InlineMath} from "../../math/Tex";
-import XmlCode from "../../XmlCode";
+import CodeFigure from "../../CodeFigure";
 
 // URDF 가 기술하는 것: link(질량·형상) 들이 joint(타입·축·부모/자식) 로 이어진 트리.
 // 여기선 base → joint → link 를 3단 중첩 부모관계로 세우고 관절을 회전시켜 정방향 기구학을 보인다.
@@ -148,9 +148,9 @@ const UrdfRobot = () => {
                     </Physics3DCanvas>
                 </CanvasFigure>
             </div>
-            <div className="lg:w-1/2 min-w-0 flex flex-col items-center gap-1 p-3">
-                <XmlCode code={XACRO} className="w-full !my-0 max-h-[440px] overflow-auto text-xs"/>
-                <span className="text-xs text-muted">arm3.urdf.xacro</span>
+            <div className="lg:w-1/2 min-w-0 flex">
+                <CodeFigure code={XACRO} label="arm3.urdf.xacro" className="w-full"
+                            codeClassName="max-h-[440px] overflow-auto text-xs"/>
             </div>
         </div>
         <dl className="mt-3 text-sm text-muted border border-border rounded-lg p-4 space-y-1.5">

--- a/document/src/index.css
+++ b/document/src/index.css
@@ -1000,6 +1000,55 @@ a.mini-chip:hover {
     }
 }
 
+/* ---------- code figures (copy + zoom) ---------- */
+.code-fig-tools {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: flex;
+    gap: 6px;
+    z-index: 2;
+}
+
+.code-fig-btn {
+    display: grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: color-mix(in srgb, var(--surface) 85%, transparent);
+    color: var(--muted);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity .16s, color .16s, border-color .16s;
+    backdrop-filter: blur(4px);
+}
+
+.group:hover .code-fig-btn,
+.code-fig-btn:focus-visible {
+    opacity: 1;
+}
+
+.code-fig-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+/* 복사 완료 확인: 테마별 초록(구문 하이라이트 태그색 재사용). */
+.code-fig-btn.is-copied {
+    color: var(--tok-tag);
+    border-color: var(--tok-tag);
+    opacity: 1;
+}
+
+/* 터치 기기는 hover 가 없으므로 버튼을 항상 노출한다. */
+@media (hover: none) {
+    .code-fig-btn {
+        opacity: 1;
+    }
+}
+
 .canvas-modal-backdrop {
     position: fixed;
     inset: 0;


### PR DESCRIPTION
## What

The Chapter 4 xacro listing (`arm3.urdf.xacro`) now behaves like the other 2D/3D figures: it gets a hover-reveal toolbar with

- a **copy-to-clipboard** button (shows a check + theme-aware green on success), and
- a **zoom** button that opens the full, scrollable listing in the shared `Modal`.

## How

- New reusable `CodeFigure` component wraps `XmlCode` with the toolbar + modal, reusing the existing `Modal` and the `canvas-zoom-btn` interaction pattern (hover-reveal, backdrop blur, always-visible on touch).
- `UrdfRobot` swaps its inline `XmlCode` + label for `CodeFigure`.
- New `.code-fig-tools` / `.code-fig-btn` styles in `index.css`; copied state reuses the theme-aware `--tok-tag` color.

## Verify

- `yarn build` passes (typecheck clean).
- Browser (`?chapter=4`): copy loads the full 1509-char xacro into the clipboard; copied state shows the check + green; zoom opens the modal with the syntax-highlighted listing and its own copy button. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)