### PR TITLE
feat(chapters): add Chapter 5 (Velocity Kinematics) and Chapter 6 (Inverse Kinematics)

### DIFF
--- a/document/src/components/pages/chapter4/PlanarChain3R.tsx
+++ b/document/src/components/pages/chapter4/PlanarChain3R.tsx
@@ -3,6 +3,7 @@ import {Circle, Line, Text} from "react-konva";
 import CoordinateSystem from "../../2d/CoordinateCanvas";
 import CanvasFigure from "../../CanvasFigure";
 import {globalToMap} from "../../../libs/konvaUtils";
+import {planarFk} from "../../../libs/planarArm";
 import {useCanvasColors} from "../../../libs/useTheme";
 
 // 3R 평면 개방연쇄의 정방향 기구학. 슬라이더로 관절각 θ1,θ2,θ3 를 돌리면 링크를 순차 누적해
@@ -25,17 +26,7 @@ const PlanarChainScene = ({width, height}: SceneProps) => {
     const colors = useCanvasColors();
     const [theta, setTheta] = useState<[number, number, number]>([0.6, 0.7, 0.5]);
 
-    const {world, phi} = useMemo(() => {
-        let x = 0, y = 0, a = 0;
-        const world = [{x, y}];
-        for (let i = 0; i < LINKS.length; i++) {
-            a += theta[i];
-            x += LINKS[i] * Math.cos(a);
-            y += LINKS[i] * Math.sin(a);
-            world.push({x, y});
-        }
-        return {world, phi: a};
-    }, [theta]);
+    const {points: world, phi} = useMemo(() => planarFk(theta, LINKS), [theta]);
 
     const px = world.map((p) => globalToMap(width, height, p.x, p.y, RESOLUTION));
     const ee = world[world.length - 1];

--- a/document/src/components/pages/chapter5/JacobianColumns.tsx
+++ b/document/src/components/pages/chapter5/JacobianColumns.tsx
@@ -1,0 +1,127 @@
+import {useMemo, useState} from "react";
+import {Arrow, Circle, Line, Text} from "react-konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap} from "../../../libs/konvaUtils";
+import {det2R, jacobian2R, planarFk, Vec2} from "../../../libs/planarArm";
+import {useCanvasColors} from "../../../libs/useTheme";
+
+// 2R 팔의 Jacobian 열 시각화. 슬라이더로 관절각을 돌리면 tip 에서 두 화살표가 뻗는다:
+// J1(관절1만 θ̇=1), J2(관절2만 θ̇=1). 두 화살표가 나란해지는 θ2=0,π 에서 det J=0 — 특이점이다.
+const LINKS = [2.5, 2] as const;
+const L1 = LINKS[0], L2 = LINKS[1];
+const RESOLUTION = 0.05;
+
+// 열 벡터 색: 관절1 = indigo(accent), 관절2 = orange. 두 색 모두 라이트/다크에서 잘 읽힌다.
+const J2_COLOR = "#f2a63a";
+
+const degrees = (rad: number) => {
+    const d = Math.round((rad * 180) / Math.PI);
+    return d === 0 ? 0 : d;
+};
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const JacobianScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [theta, setTheta] = useState<[number, number]>([0.6, 0.9]);
+
+    const {world, cols, det} = useMemo(() => {
+        const {points} = planarFk(theta, [...LINKS]);
+        const cols = jacobian2R(theta[0], theta[1], L1, L2);
+        return {world: points, cols, det: det2R(theta[1], L1, L2)};
+    }, [theta]);
+
+    const px = world.map((p) => globalToMap(width, height, p.x, p.y, RESOLUTION));
+    const tip = world[world.length - 1];
+    const tipPx = px[px.length - 1];
+
+    // 열 벡터(단위: length/rad)를 tip 에서 맵 좌표로 그린다. y 는 화면 아래가 +라 부호 반전.
+    const arrowEnd = (v: Vec2) => ({x: tipPx.x + v.x / RESOLUTION, y: tipPx.y - v.y / RESOLUTION});
+    const e1 = arrowEnd(cols[0]);
+    const e2 = arrowEnd(cols[1]);
+    const singular = Math.abs(det) < 0.15;
+
+    const setJoint = (i: number, v: number) =>
+        setTheta((prev) => {
+            const next = [...prev] as [number, number];
+            next[i] = v;
+            return next;
+        });
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {px.slice(0, -1).map((p, i) => (
+                    <Line
+                        key={`link-${i}`}
+                        points={[p.x, p.y, px[i + 1].x, px[i + 1].y]}
+                        stroke={colors.text}
+                        strokeWidth={4}
+                        lineCap="round"
+                        opacity={0.75}
+                    />
+                ))}
+                {px.slice(0, -1).map((p, i) => (
+                    <Circle key={`joint-${i}`} x={p.x} y={p.y} radius={5} fill={colors.surface}
+                            stroke={colors.text} strokeWidth={2}/>
+                ))}
+                <Arrow points={[tipPx.x, tipPx.y, e1.x, e1.y]} stroke={colors.accent} fill={colors.accent}
+                       strokeWidth={3} pointerLength={9} pointerWidth={9}/>
+                <Arrow points={[tipPx.x, tipPx.y, e2.x, e2.y]} stroke={J2_COLOR} fill={J2_COLOR}
+                       strokeWidth={3} pointerLength={9} pointerWidth={9}/>
+                <Text x={e1.x + 6} y={e1.y - 6} text="J₁" fontSize={14} fontStyle="bold" fill={colors.accent}/>
+                <Text x={e2.x + 6} y={e2.y - 6} text="J₂" fontSize={14} fontStyle="bold" fill={J2_COLOR}/>
+                <Circle x={tipPx.x} y={tipPx.y} radius={6} fill={colors.text}/>
+                <Text x={tipPx.x + 10} y={tipPx.y + 6} text={`(${tip.x.toFixed(2)}, ${tip.y.toFixed(2)})`}
+                      fontSize={12} fill={colors.muted}/>
+            </CoordinateSystem>
+            <div className="w-full flex flex-col gap-1 text-xs text-muted">
+                {[0, 1].map((i) => (
+                    <label key={i} className="flex items-center gap-2">
+                        <span className="w-8 shrink-0">θ{i + 1}</span>
+                        <input
+                            type="range"
+                            min={-Math.PI}
+                            max={Math.PI}
+                            step={0.01}
+                            value={theta[i]}
+                            onChange={(e) => setJoint(i, parseFloat(e.target.value))}
+                            className="w-full accent-[var(--accent)]"
+                            aria-label={`joint angle theta ${i + 1}`}
+                        />
+                        <span className="w-12 shrink-0 text-right tabular-nums">{degrees(theta[i])}°</span>
+                    </label>
+                ))}
+                <div className="text-center pt-1">
+                    det&nbsp;J = {det.toFixed(2)}{" "}
+                    {singular
+                        ? <span className="text-[var(--accent)] font-semibold">· singular: J₁ ∥ J₂</span>
+                        : <span>· full rank</span>}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const JacobianColumns = () => {
+    return <CanvasFigure
+        label="Jacobian columns · tip velocity of each joint"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<JacobianScene width={460} height={460}/>}
+    >
+        <JacobianScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default JacobianColumns;

--- a/document/src/components/pages/chapter5/ManipulabilityEllipse.tsx
+++ b/document/src/components/pages/chapter5/ManipulabilityEllipse.tsx
@@ -1,0 +1,139 @@
+import {useMemo, useState} from "react";
+import {Circle, Ellipse, Line} from "react-konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap} from "../../../libs/konvaUtils";
+import {jacobian2R, manipulabilityEllipse, planarFk} from "../../../libs/planarArm";
+import {useCanvasColors} from "../../../libs/useTheme";
+
+// 조작성 타원: tip 이 각 방향으로 얼마나 쉽게 움직일 수 있는지를 나타내는 타원.
+// 단위 관절속도 원을 Jacobian 으로 사상한 결과다. 특이점(θ2→0,π)에서 선분으로 붕괴한다.
+// force 타원(주축이 조작성 타원의 역수)을 겹쳐 velocity↔force 의 상보성을 보인다.
+const LINKS = [2.5, 2] as const;
+const L1 = LINKS[0], L2 = LINKS[1];
+const RESOLUTION = 0.05;
+const FORCE_COLOR = "#f2a63a";
+
+const degrees = (rad: number) => {
+    const d = Math.round((rad * 180) / Math.PI);
+    return d === 0 ? 0 : d;
+};
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const ManipulabilityScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [theta, setTheta] = useState<[number, number]>([0.5, 1.1]);
+    const [showForce, setShowForce] = useState(false);
+
+    const {world, ell} = useMemo(() => {
+        const {points} = planarFk(theta, [...LINKS]);
+        const [j1, j2] = jacobian2R(theta[0], theta[1], L1, L2);
+        return {world: points, ell: manipulabilityEllipse(j1, j2)};
+    }, [theta]);
+
+    const px = world.map((p) => globalToMap(width, height, p.x, p.y, RESOLUTION));
+    const tipPx = px[px.length - 1];
+    // Konva 회전은 시계방향(+y 아래)이므로 수학적 반시계 각도를 부호 반전한다.
+    const rotationDeg = (-ell.angle * 180) / Math.PI;
+    const scale = 1 / RESOLUTION;
+    const ratio = ell.minor > 1e-4 ? ell.major / ell.minor : Infinity;
+
+    const setJoint = (i: number, v: number) =>
+        setTheta((prev) => {
+            const next = [...prev] as [number, number];
+            next[i] = v;
+            return next;
+        });
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {/* force 타원: 주축 반지름이 조작성 타원의 역수 — 잘 움직이는 방향이 힘내기 어려운 방향. */}
+                {showForce && ell.minor > 1e-4 && (
+                    <Ellipse
+                        x={tipPx.x}
+                        y={tipPx.y}
+                        radiusX={(1 / ell.major) * scale}
+                        radiusY={(1 / ell.minor) * scale}
+                        rotation={rotationDeg}
+                        stroke={FORCE_COLOR}
+                        strokeWidth={2}
+                        dash={[6, 4]}
+                    />
+                )}
+                <Ellipse
+                    x={tipPx.x}
+                    y={tipPx.y}
+                    radiusX={Math.max(ell.major * scale, 1)}
+                    radiusY={Math.max(ell.minor * scale, 1)}
+                    rotation={rotationDeg}
+                    fill={colors.accent}
+                    opacity={0.28}
+                    stroke={colors.accent}
+                    strokeWidth={2}
+                />
+                {px.slice(0, -1).map((p, i) => (
+                    <Line key={`link-${i}`} points={[p.x, p.y, px[i + 1].x, px[i + 1].y]}
+                          stroke={colors.text} strokeWidth={4} lineCap="round" opacity={0.75}/>
+                ))}
+                {px.slice(0, -1).map((p, i) => (
+                    <Circle key={`joint-${i}`} x={p.x} y={p.y} radius={5} fill={colors.surface}
+                            stroke={colors.text} strokeWidth={2}/>
+                ))}
+                <Circle x={tipPx.x} y={tipPx.y} radius={5} fill={colors.text}/>
+            </CoordinateSystem>
+            <div className="w-full flex flex-col gap-1 text-xs text-muted">
+                {[0, 1].map((i) => (
+                    <label key={i} className="flex items-center gap-2">
+                        <span className="w-8 shrink-0">θ{i + 1}</span>
+                        <input
+                            type="range"
+                            min={-Math.PI}
+                            max={Math.PI}
+                            step={0.01}
+                            value={theta[i]}
+                            onChange={(e) => setJoint(i, parseFloat(e.target.value))}
+                            className="w-full accent-[var(--accent)]"
+                            aria-label={`joint angle theta ${i + 1}`}
+                        />
+                        <span className="w-12 shrink-0 text-right tabular-nums">{degrees(theta[i])}°</span>
+                    </label>
+                ))}
+                <div className="flex items-center justify-between pt-1">
+                    <span>
+                        ℓ_max/ℓ_min = {ratio === Infinity ? "∞ (singular)" : ratio.toFixed(2)}
+                    </span>
+                    <label className="flex items-center gap-1.5 cursor-pointer">
+                        <input type="checkbox" checked={showForce}
+                               onChange={(e) => setShowForce(e.target.checked)}
+                               className="accent-[var(--accent)]"/>
+                        <span style={{color: FORCE_COLOR}}>force ellipse</span>
+                    </label>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const ManipulabilityEllipse = () => {
+    return <CanvasFigure
+        label="manipulability ellipse · isotropy of the 2R tip"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<ManipulabilityScene width={460} height={460}/>}
+    >
+        <ManipulabilityScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default ManipulabilityEllipse;

--- a/document/src/components/pages/chapter6/AnalyticIK2R.tsx
+++ b/document/src/components/pages/chapter6/AnalyticIK2R.tsx
@@ -1,0 +1,114 @@
+import {useMemo, useState} from "react";
+import {Circle, Line, Ring, Text} from "react-konva";
+import type Konva from "konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap, mapToGlobal} from "../../../libs/konvaUtils";
+import {ik2R, IkSolution, planarFk} from "../../../libs/planarArm";
+import {useCanvasColors} from "../../../libs/useTheme";
+
+// 2R 위치 역기구학: 목표점(주황)을 드래그하면 그 점에 도달하는 두 해(righty·lefty)를 실시간으로 그린다.
+// 작업공간(annulus) 밖으로 끌면 해가 없어지고 목표점이 회색으로 바뀐다.
+const L1 = 2.2, L2 = 1.3;
+const RESOLUTION = 0.05;
+const LEFTY_COLOR = "#f2a63a";
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const IkScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [target, setTarget] = useState({x: 2.0, y: 1.4});
+
+    const sol = useMemo(() => ik2R(target.x, target.y, L1, L2), [target]);
+
+    // 한 해(관절각)를 맵 좌표 링크 폴리라인으로 변환한다.
+    const armPoints = (s: IkSolution) => {
+        const {points} = planarFk([s.theta1, s.theta2], [L1, L2]);
+        return points.flatMap((p) => {
+            const m = globalToMap(width, height, p.x, p.y, RESOLUTION);
+            return [m.x, m.y];
+        });
+    };
+
+    const tPx = globalToMap(width, height, target.x, target.y, RESOLUTION);
+    const center = globalToMap(width, height, 0, 0, RESOLUTION);
+    const scale = 1 / RESOLUTION;
+
+    const onDrag = (e: Konva.KonvaEventObject<DragEvent>) => {
+        const g = mapToGlobal(width, height, e.target.x(), e.target.y(), RESOLUTION);
+        setTarget({x: g.x, y: g.y});
+    };
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {/* 작업공간 annulus: 안쪽 |L1−L2|, 바깥 L1+L2 */}
+                <Ring x={center.x} y={center.y} innerRadius={Math.abs(L1 - L2) * scale}
+                      outerRadius={(L1 + L2) * scale} fill={colors.accent} opacity={0.08}/>
+                <Circle x={center.x} y={center.y} radius={(L1 + L2) * scale} stroke={colors.border} strokeWidth={1}/>
+                <Circle x={center.x} y={center.y} radius={Math.abs(L1 - L2) * scale} stroke={colors.border}
+                        strokeWidth={1}/>
+
+                {sol.reachable && sol.lefty && (
+                    <Line points={armPoints(sol.lefty)} stroke={LEFTY_COLOR} strokeWidth={4} lineCap="round"
+                          dash={[8, 5]} opacity={0.9}/>
+                )}
+                {sol.reachable && sol.righty && (
+                    <Line points={armPoints(sol.righty)} stroke={colors.accent} strokeWidth={4} lineCap="round"/>
+                )}
+                <Circle x={center.x} y={center.y} radius={5} fill={colors.surface} stroke={colors.text}
+                        strokeWidth={2}/>
+
+                {/* 드래그 가능한 목표점 */}
+                <Circle
+                    x={tPx.x}
+                    y={tPx.y}
+                    radius={8}
+                    draggable
+                    fill={sol.reachable ? "#e0533d" : colors.muted}
+                    stroke={colors.surface}
+                    strokeWidth={2}
+                    onDragMove={onDrag}
+                />
+                <Text x={tPx.x + 12} y={tPx.y - 6} text={`(${target.x.toFixed(2)}, ${target.y.toFixed(2)})`}
+                      fontSize={12} fill={colors.muted}/>
+            </CoordinateSystem>
+            <div className="w-full text-xs text-muted text-center">
+                {sol.reachable && sol.righty && sol.lefty ? (
+                    <span>
+                        <span className="text-[var(--accent)] font-semibold">righty</span>{" "}
+                        θ = ({(sol.righty.theta1 * 180 / Math.PI).toFixed(0)}°,{" "}
+                        {(sol.righty.theta2 * 180 / Math.PI).toFixed(0)}°) ·{" "}
+                        <span style={{color: LEFTY_COLOR}} className="font-semibold">lefty</span>{" "}
+                        θ = ({(sol.lefty.theta1 * 180 / Math.PI).toFixed(0)}°,{" "}
+                        {(sol.lefty.theta2 * 180 / Math.PI).toFixed(0)}°)
+                    </span>
+                ) : (
+                    <span>outside the workspace — no solution. Drag the target back into the annulus.</span>
+                )}
+            </div>
+        </div>
+    );
+};
+
+const AnalyticIK2R = () => {
+    return <CanvasFigure
+        label="analytic IK · drag the target for lefty / righty solutions"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<IkScene width={460} height={460}/>}
+    >
+        <IkScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default AnalyticIK2R;

--- a/document/src/components/pages/chapter6/NewtonRaphsonIK.tsx
+++ b/document/src/components/pages/chapter6/NewtonRaphsonIK.tsx
@@ -1,0 +1,148 @@
+import {useMemo, useState} from "react";
+import {Circle, Line, Text} from "react-konva";
+import type Konva from "konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap, mapToGlobal} from "../../../libs/konvaUtils";
+import {jacobian2R, planarFk, Vec2} from "../../../libs/planarArm";
+import {useCanvasColors} from "../../../libs/useTheme";
+
+// 수치 역기구학(Newton–Raphson): 초기 추정 θ0 에서 시작해 Δθ = J⁻¹(x_d − f(θ)) 를 반복 적용,
+// tip 이 목표(goal)로 수렴한다. "Step" 으로 한 번에 한 반복씩 진행하며 tip 궤적과 오차를 보인다.
+const L1 = 2, L2 = 1.5;
+const RESOLUTION = 0.06;
+const GOAL_COLOR = "#e0533d";
+const TOL = 1e-3;
+const INITIAL_GUESS: [number, number] = [0, 0.5];
+// Newton 방향으로 가되 한 스텝의 관절 변화량을 제한한다(trust region). 초기 추정이 멀 때
+// 1차 근사가 과도하게 벗어나 다른 해로 튀는 것을 막아 수렴을 부드럽게 보여준다.
+const MAX_STEP = 0.5;
+
+const fk = (t: [number, number]): Vec2 => {
+    const {points} = planarFk(t, [L1, L2]);
+    return points[points.length - 1];
+};
+
+// 2×2 좌표 Jacobian 을 역행렬로 풀어 Newton 스텝을 계산한다. 특이점 근처면 스텝을 생략한다.
+const newtonStep = (t: [number, number], goal: Vec2): [number, number] | null => {
+    const f = fk(t);
+    const ex = goal.x - f.x, ey = goal.y - f.y;
+    const [j1, j2] = jacobian2R(t[0], t[1], L1, L2);
+    const det = j1.x * j2.y - j2.x * j1.y;
+    if (Math.abs(det) < 1e-4) return null;
+    let d1 = (j2.y * ex - j2.x * ey) / det;
+    let d2 = (-j1.y * ex + j1.x * ey) / det;
+    const n = Math.hypot(d1, d2);
+    if (n > MAX_STEP) {
+        d1 *= MAX_STEP / n;
+        d2 *= MAX_STEP / n;
+    }
+    return [t[0] + d1, t[1] + d2];
+};
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const NewtonScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [goal, setGoal] = useState<Vec2>(() => fk([Math.PI / 6, Math.PI / 2])); // θ_d = (30°, 90°)
+    const [theta, setTheta] = useState<[number, number]>(INITIAL_GUESS);
+    const [trace, setTrace] = useState<Vec2[]>(() => [fk(INITIAL_GUESS)]);
+    const [iter, setIter] = useState(0);
+
+    const err = useMemo(() => {
+        const f = fk(theta);
+        return Math.hypot(goal.x - f.x, goal.y - f.y);
+    }, [theta, goal]);
+    const converged = err < TOL;
+
+    const reset = (g: Vec2) => {
+        setTheta(INITIAL_GUESS);
+        setTrace([fk(INITIAL_GUESS)]);
+        setIter(0);
+        setGoal(g);
+    };
+
+    const step = () => {
+        if (converged) return;
+        const next = newtonStep(theta, goal);
+        if (!next) return;
+        setTheta(next);
+        setTrace((prev) => [...prev, fk(next)]);
+        setIter((i) => i + 1);
+    };
+
+    const toPx = (p: Vec2) => globalToMap(width, height, p.x, p.y, RESOLUTION);
+    const armPx = planarFk(theta, [L1, L2]).points.flatMap((p) => {
+        const m = toPx(p);
+        return [m.x, m.y];
+    });
+    const tracePx = trace.flatMap((p) => {
+        const m = toPx(p);
+        return [m.x, m.y];
+    });
+    const gPx = toPx(goal);
+    const center = toPx({x: 0, y: 0});
+
+    const onDragGoal = (e: Konva.KonvaEventObject<DragEvent>) => {
+        reset(mapToGlobal(width, height, e.target.x(), e.target.y(), RESOLUTION));
+    };
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {/* tip 궤적: 반복마다 목표로 다가가는 경로 */}
+                {trace.length > 1 && (
+                    <Line points={tracePx} stroke={colors.muted} strokeWidth={1.5} dash={[4, 4]}/>
+                )}
+                {trace.map((p, i) => {
+                    const m = toPx(p);
+                    return <Circle key={`tr-${i}`} x={m.x} y={m.y} radius={3} fill={colors.muted}/>;
+                })}
+                <Line points={armPx} stroke={colors.accent} strokeWidth={4} lineCap="round"/>
+                <Circle x={center.x} y={center.y} radius={5} fill={colors.surface} stroke={colors.text}
+                        strokeWidth={2}/>
+                <Circle x={gPx.x} y={gPx.y} radius={8} draggable fill={GOAL_COLOR} stroke={colors.surface}
+                        strokeWidth={2} onDragMove={onDragGoal}/>
+                <Text x={gPx.x + 12} y={gPx.y - 6} text="goal" fontSize={12} fill={GOAL_COLOR} fontStyle="bold"/>
+            </CoordinateSystem>
+            <div className="w-full flex items-center justify-between text-xs text-muted">
+                <div className="flex gap-2">
+                    <button type="button" onClick={step} disabled={converged}
+                            className="px-3 py-1 rounded-md bg-[var(--accent)] text-white font-semibold disabled:opacity-40">
+                        Step
+                    </button>
+                    <button type="button" onClick={() => reset(goal)}
+                            className="px-3 py-1 rounded-md border border-border">
+                        Reset
+                    </button>
+                </div>
+                <div className="text-right tabular-nums">
+                    iter {iter} · ‖error‖ = {err.toFixed(4)} m{" "}
+                    {converged && <span className="text-[var(--accent)] font-semibold">· converged</span>}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const NewtonRaphsonIK = () => {
+    return <CanvasFigure
+        label="numerical IK · Newton–Raphson iteration"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<NewtonScene width={460} height={460}/>}
+    >
+        <NewtonScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default NewtonRaphsonIK;

--- a/document/src/libs/planarArm.ts
+++ b/document/src/libs/planarArm.ts
@@ -1,0 +1,83 @@
+// 평면 개방연쇄(planar open chain)의 공용 기구학. Ch4~6 의 2R/3R 그림이 공유해
+// 정방향/역방향 기구학·Jacobian·조작성 타원 계산을 한 곳에서 관리한다.
+
+export interface Vec2 {
+    x: number;
+    y: number;
+}
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+// 관절각을 base 부터 누적해 각 관절 위치와 end-effector 방향 φ 를 구한다.
+export function planarFk(thetas: number[], links: number[]): {points: Vec2[]; phi: number} {
+    let x = 0, y = 0, a = 0;
+    const points: Vec2[] = [{x, y}];
+    for (let i = 0; i < links.length; i++) {
+        a += thetas[i];
+        x += links[i] * Math.cos(a);
+        y += links[i] * Math.sin(a);
+        points.push({x, y});
+    }
+    return {points, phi: a};
+}
+
+// 2R 팔의 2×2 기하 Jacobian. 각 열은 해당 관절만 단위 속도로 돌 때의 tip 속도 벡터다.
+export function jacobian2R(t1: number, t2: number, l1: number, l2: number): [Vec2, Vec2] {
+    const s1 = Math.sin(t1), c1 = Math.cos(t1);
+    const s12 = Math.sin(t1 + t2), c12 = Math.cos(t1 + t2);
+    return [
+        {x: -l1 * s1 - l2 * s12, y: l1 * c1 + l2 * c12},
+        {x: -l2 * s12, y: l2 * c12},
+    ];
+}
+
+// det J = l1 l2 sin θ2 — 0 이 되는 곳(θ2 = 0 또는 π)이 특이점이다.
+export function det2R(t2: number, l1: number, l2: number): number {
+    return l1 * l2 * Math.sin(t2);
+}
+
+export interface Ellipse2 {
+    // 주축(major)·부축(minor) 반지름 = J 의 특이값(√(JJᵀ 고윳값)). angle 은 major 축 방향.
+    major: number;
+    minor: number;
+    angle: number;
+}
+
+// 조작성 타원: 단위 관절속도 원을 J 로 사상한 타원. JJᵀ 의 고유분해로 반축과 방향을 얻는다.
+export function manipulabilityEllipse(j1: Vec2, j2: Vec2): Ellipse2 {
+    const a = j1.x * j1.x + j2.x * j2.x;
+    const b = j1.x * j1.y + j2.x * j2.y;
+    const c = j1.y * j1.y + j2.y * j2.y;
+    const mid = (a + c) / 2;
+    const half = Math.sqrt(Math.max(0, ((a - c) / 2) ** 2 + b * b));
+    return {
+        major: Math.sqrt(Math.max(0, mid + half)),
+        minor: Math.sqrt(Math.max(0, mid - half)),
+        angle: 0.5 * Math.atan2(2 * b, a - c),
+    };
+}
+
+export interface IkSolution {
+    theta1: number;
+    theta2: number;
+}
+
+// 2R 위치 역기구학. 작업공간(annulus) 밖이면 reachable=false, 안이면 lefty/righty 두 해를 준다.
+export function ik2R(
+    x: number,
+    y: number,
+    l1: number,
+    l2: number,
+): {reachable: boolean; righty?: IkSolution; lefty?: IkSolution} {
+    const r2 = x * x + y * y;
+    const r = Math.sqrt(r2);
+    if (r > l1 + l2 + 1e-9 || r < Math.abs(l1 - l2) - 1e-9) return {reachable: false};
+    const gamma = Math.atan2(y, x);
+    const beta = Math.acos(clamp((l1 * l1 + l2 * l2 - r2) / (2 * l1 * l2), -1, 1));
+    const alpha = Math.acos(clamp((r2 + l1 * l1 - l2 * l2) / (2 * l1 * r), -1, 1));
+    return {
+        reachable: true,
+        righty: {theta1: gamma - alpha, theta2: Math.PI - beta},
+        lefty: {theta1: gamma + alpha, theta2: beta - Math.PI},
+    };
+}

--- a/document/src/pages/chapters/Chapter5.tsx
+++ b/document/src/pages/chapters/Chapter5.tsx
@@ -1,0 +1,120 @@
+import {BlockMath, InlineMath} from "../../components/math/Tex";
+import JacobianColumns from "../../components/pages/chapter5/JacobianColumns";
+import ManipulabilityEllipse from "../../components/pages/chapter5/ManipulabilityEllipse";
+
+const Chapter5 = () => {
+    return (
+        <>
+            <h2>Manipulator Jacobian</h2>
+            <p>
+                Forward kinematics answers <em>where</em> the end-effector is for a given set of joint
+                positions. Velocity kinematics answers the related question: given the joint <em>velocities</em>{" "}
+                <InlineMath math='\dot\theta'/>, how fast and in what direction does the end-effector move? Writing
+                the forward kinematics as <InlineMath math='x = f(\theta)'/> and differentiating by the chain rule,
+            </p>
+            <BlockMath math={`\\dot{x} = \\frac{\\partial f(\\theta)}{\\partial \\theta}\\,\\dot\\theta = J(\\theta)\\,\\dot\\theta`}/>
+            <p>
+                The matrix <InlineMath math='J(\theta)'/> is the <strong>Jacobian</strong>. It is the linear map
+                from joint velocities to end-effector velocity, and — because the trigonometric terms depend on the
+                configuration — it changes as the robot moves.
+            </p>
+            <p>
+                For the 2R planar chain the tip velocity is <InlineMath math='v_\text{tip} = J_1(\theta)\dot\theta_1 + J_2(\theta)\dot\theta_2'/>.
+                Each column <InlineMath math='J_i(\theta)'/> has a direct physical meaning: it is the tip velocity
+                produced when joint <InlineMath math='i'/> turns at unit speed and the others are held still. Drag
+                the sliders below — the two arrows are exactly <InlineMath math='J_1'/> and <InlineMath math='J_2'/>.
+                When they line up (at <InlineMath math='\theta_2 = 0'/> or <InlineMath math='\pm\pi'/>) the tip can
+                no longer move sideways, <InlineMath math='\det J = L_1 L_2 \sin\theta_2'/> vanishes, and the arm is
+                at a <strong>singularity</strong>.
+            </p>
+            <JacobianColumns/>
+            <p>
+                In the general spatial case the tip velocity is the six-dimensional twist{" "}
+                <InlineMath math='\mathcal{V}'/>, and the same idea holds: column <InlineMath math='i'/> of the
+                Jacobian is the screw axis of joint <InlineMath math='i'/>, expressed for the <em>current</em>{" "}
+                configuration rather than the zero configuration used by the product-of-exponentials formula.
+            </p>
+
+            <h2>Space and Body Jacobian</h2>
+            <p>
+                Just as a twist can be written in the fixed frame (<InlineMath math='\mathcal{V}_s'/>) or the
+                end-effector frame (<InlineMath math='\mathcal{V}_b'/>), there are two Jacobians. The{" "}
+                <strong>space Jacobian</strong> <InlineMath math='J_s(\theta)'/> satisfies{" "}
+                <InlineMath math='\mathcal{V}_s = J_s(\theta)\dot\theta'/>, with columns
+            </p>
+            <BlockMath math={`J_{si}(\\theta) = \\big[\\mathrm{Ad}_{e^{[\\mathcal{S}_1]\\theta_1}\\cdots e^{[\\mathcal{S}_{i-1}]\\theta_{i-1}}}\\big]\\,\\mathcal{S}_i, \\qquad J_{s1} = \\mathcal{S}_1`}/>
+            <p>
+                Each column is the joint screw axis <InlineMath math='\mathcal{S}_i'/> after it has been carried
+                along by the first <InlineMath math='i-1'/> joints. The <strong>body Jacobian</strong>{" "}
+                <InlineMath math='J_b(\theta)'/> satisfies <InlineMath math='\mathcal{V}_b = J_b(\theta)\dot\theta'/>,
+                with columns built the same way from the body screw axes <InlineMath math='\mathcal{B}_i'/>, working
+                inward from the last joint. The two are related by the adjoint map,
+            </p>
+            <BlockMath math={`J_b(\\theta) = \\big[\\mathrm{Ad}_{T_{bs}}\\big] J_s(\\theta), \\qquad J_s(\\theta) = \\big[\\mathrm{Ad}_{T_{sb}}\\big] J_b(\\theta)`}/>
+            <p>
+                Since the adjoint map is always invertible, <InlineMath math='J_s(\theta)'/> and{" "}
+                <InlineMath math='J_b(\theta)'/> always have the <strong>same rank</strong> — singularities are a
+                property of the configuration, not of the frame we chose to describe it in.
+            </p>
+
+            <h2>Statics of Open Chains</h2>
+            <p>
+                The Jacobian also governs statics. By conservation of power, at static equilibrium the power
+                delivered by the joint torques equals the power the end-effector exerts on its environment,{" "}
+                <InlineMath math='\tau^{\mathsf T}\dot\theta = \mathcal{F}^{\mathsf T}\mathcal{V}'/>. Substituting{" "}
+                <InlineMath math='\mathcal{V} = J(\theta)\dot\theta'/> and requiring this for all{" "}
+                <InlineMath math='\dot\theta'/> gives the central relation
+            </p>
+            <BlockMath math={`\\tau = J^{\\mathsf T}(\\theta)\\,\\mathcal{F}`}/>
+            <p>
+                So the same Jacobian that maps joint velocities to a twist maps an end-effector wrench{" "}
+                <InlineMath math='\mathcal{F}'/> back to the joint torques needed to balance it. A wrench in the
+                null space of <InlineMath math='J^{\mathsf T}'/> requires no joint torque at all: the structure
+                carries it. This is why an outstretched arm supports a heavy suitcase most easily when the elbow is
+                straight — at that singularity the load passes directly through the joints.
+            </p>
+
+            <h2>Singularities</h2>
+            <p>
+                A <strong>kinematic singularity</strong> is a configuration where <InlineMath math='J(\theta)'/>{" "}
+                loses rank, so the end-effector loses the ability to move instantaneously in one or more directions.
+                For a spatial 6R arm several geometric patterns force a rank drop, for example:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+                <li>two revolute joint axes become <strong>collinear</strong>;</li>
+                <li>three revolute axes become <strong>parallel and coplanar</strong>;</li>
+                <li>four revolute axes <strong>intersect at a common point</strong>;</li>
+                <li>six revolute axes all <strong>intersect a common line</strong>.</li>
+            </ul>
+            <p>
+                In every case two or more Jacobian columns become linearly dependent. Because{" "}
+                <InlineMath math='J_s'/> and <InlineMath math='J_b'/> share their rank, and relocating the base or
+                the end-effector frame leaves the Jacobian's rank unchanged, singularities are intrinsic to the
+                mechanism's posture.
+            </p>
+
+            <h2>Manipulability and Force Ellipsoids</h2>
+            <p>
+                How close is a posture to a singularity, and in which directions is the arm nimble or clumsy? Map
+                the unit circle of "iso-effort" joint velocities through the Jacobian: it becomes the{" "}
+                <strong>manipulability ellipsoid</strong>, whose principal axes are the eigenvectors of{" "}
+                <InlineMath math='J J^{\mathsf T}'/> and whose semi-axis lengths are the singular values{" "}
+                <InlineMath math='\ell_i'/> of <InlineMath math='J'/>. A round ellipse means the tip moves equally
+                well in all directions; a thin one means it is nearly singular; at a singularity it collapses to a
+                line segment.
+            </p>
+            <p>
+                Sweep the sliders and watch the ellipse stretch and flatten. The ratio{" "}
+                <InlineMath math='\ell_\text{max}/\ell_\text{min}'/> measures the distance from a singularity — it
+                runs off to infinity as <InlineMath math='\theta_2 \to 0'/>. Toggle the <strong>force
+                ellipsoid</strong>: its axes are the <em>reciprocals</em> of the manipulability axes, so a
+                direction that is easy to move is hard to push in, and vice versa. At a singularity the
+                manipulability ellipse thins to a segment while the force ellipse grows without bound along the
+                orthogonal direction.
+            </p>
+            <ManipulabilityEllipse/>
+        </>
+    )
+}
+
+export default Chapter5

--- a/document/src/pages/chapters/Chapter6.tsx
+++ b/document/src/pages/chapters/Chapter6.tsx
@@ -1,0 +1,94 @@
+import {BlockMath, InlineMath} from "../../components/math/Tex";
+import AnalyticIK2R from "../../components/pages/chapter6/AnalyticIK2R";
+import NewtonRaphsonIK from "../../components/pages/chapter6/NewtonRaphsonIK";
+
+const Chapter6 = () => {
+    return (
+        <>
+            <h2>Inverse Kinematics</h2>
+            <p>
+                <strong>Definition</strong> : for an open chain with forward kinematics{" "}
+                <InlineMath math='T(\theta)'/>, the inverse kinematics problem is: given a desired end-effector
+                configuration <InlineMath math='X \in SE(3)'/>, find the joint values <InlineMath math='\theta'/>{" "}
+                that satisfy <InlineMath math='T(\theta) = X'/>.
+            </p>
+            <p>
+                Unlike forward kinematics, which has a single unique answer, inverse kinematics may have{" "}
+                <strong>no solution, a finite number, or infinitely many</strong>. Take the 2R arm reaching for a
+                point <InlineMath math='(x, y)'/>. Its reachable set — the <strong>workspace</strong> — is the
+                annulus between radii <InlineMath math='|L_1 - L_2|'/> and <InlineMath math='L_1 + L_2'/>. A target
+                outside the annulus has no solution; one on a boundary circle has exactly one; one strictly inside
+                has two, the "elbow-up" and "elbow-down" postures.
+            </p>
+
+            <h2>Analytic Inverse Kinematics</h2>
+            <p>
+                When the geometry is simple enough, the solution can be written in closed form. For the 2R arm the
+                law of cosines gives the interior angles directly. With <InlineMath math='r^2 = x^2 + y^2'/>,
+            </p>
+            <BlockMath math={`\\beta = \\cos^{-1}\\!\\frac{L_1^2 + L_2^2 - r^2}{2 L_1 L_2}, \\qquad \\alpha = \\cos^{-1}\\!\\frac{r^2 + L_1^2 - L_2^2}{2 L_1 r}, \\qquad \\gamma = \\operatorname{atan2}(y, x)`}/>
+            <p>
+                which yield the two solutions
+            </p>
+            <BlockMath math={`\\text{righty:}\\ \\theta_1 = \\gamma - \\alpha,\\ \\theta_2 = \\pi - \\beta \\qquad\\qquad \\text{lefty:}\\ \\theta_1 = \\gamma + \\alpha,\\ \\theta_2 = \\beta - \\pi`}/>
+            <p>
+                The two-argument arctangent <InlineMath math='\operatorname{atan2}(y, x)'/> is essential here: it
+                returns the correct quadrant over <InlineMath math='(-\pi, \pi]'/>, unlike{" "}
+                <InlineMath math='\tan^{-1}(y/x)'/>. Drag the target below through the workspace and watch both
+                solutions track it; drag it outside the annulus and both disappear.
+            </p>
+            <AnalyticIK2R/>
+            <p>
+                The same decoupling scales to six-dof arms of special design. For a <strong>PUMA-type</strong> 6R
+                arm the wrist axes intersect at a point, so the problem splits into an <strong>inverse-position</strong>{" "}
+                subproblem for the first three joints (solved with the same planar-arm trigonometry, giving up to
+                four arm postures) and an <strong>inverse-orientation</strong> subproblem for the wrist, solved as a
+                set of ZYX Euler angles. A <strong>Stanford-type</strong> arm replaces the elbow with a prismatic
+                joint and is handled the same way.
+            </p>
+
+            <h2>Numerical Inverse Kinematics</h2>
+            <p>
+                Most robots have no closed-form solution. The <strong>Newton–Raphson</strong> method solves{" "}
+                <InlineMath math='x_d - f(\theta) = 0'/> iteratively. Expanding the forward kinematics to first
+                order about a guess <InlineMath math='\theta^0'/> gives{" "}
+                <InlineMath math='J(\theta^0)\,\Delta\theta = x_d - f(\theta^0)'/>, so each step corrects the guess
+                by
+            </p>
+            <BlockMath math={`\\theta^{k+1} = \\theta^{k} + J^{\\dagger}(\\theta^{k})\\big(x_d - f(\\theta^{k})\\big)`}/>
+            <p>
+                where <InlineMath math='J^{\dagger}'/> is the Moore–Penrose <strong>pseudoinverse</strong>, which
+                reduces to <InlineMath math='J^{-1}'/> when the Jacobian is square and nonsingular but still gives a
+                sensible least-squares (or minimum-norm) answer when the robot is redundant or near a singularity.
+                Iteration continues until the error <InlineMath math='\lVert x_d - f(\theta)\rVert'/> falls below a
+                tolerance. Step through the iteration below: the tip walks toward the goal, converging in a handful
+                of steps. Drag the goal to see the process restart — the method converges to whichever solution's{" "}
+                <em>basin of attraction</em> contains the initial guess.
+            </p>
+            <NewtonRaphsonIK/>
+            <p>
+                To drive a full pose <InlineMath math='T_{sd} \in SE(3)'/> rather than a coordinate vector, the same
+                algorithm uses the body Jacobian <InlineMath math='J_b'/> and replaces the error with the body twist{" "}
+                <InlineMath math='[\mathcal{V}_b] = \log\!\big(T_{sb}^{-1}(\theta)\,T_{sd}\big)'/> that would carry
+                the current frame to the goal in unit time.
+            </p>
+
+            <h2>Inverse Velocity Kinematics</h2>
+            <p>
+                A related problem underlies trajectory following: given a desired end-effector twist{" "}
+                <InlineMath math='\mathcal{V}_d'/>, what joint velocities produce it? Inverting{" "}
+                <InlineMath math='J(\theta)\dot\theta = \mathcal{V}_d'/> with the pseudoinverse gives
+            </p>
+            <BlockMath math={`\\dot\\theta = J^{\\dagger}(\\theta)\\,\\mathcal{V}_d`}/>
+            <p>
+                For a redundant robot (<InlineMath math='n > 6'/>) this returns the minimum-norm joint velocity,
+                leaving an <InlineMath math='(n-6)'/>-dimensional family of internal motions free. Those extra
+                degrees of freedom can be used to optimize a secondary criterion — for instance weighting the joints
+                by the mass they move, so the solution minimizes kinetic energy while still realizing{" "}
+                <InlineMath math='\mathcal{V}_d'/>.
+            </p>
+        </>
+    )
+}
+
+export default Chapter6

--- a/document/src/pages/chapters/index.ts
+++ b/document/src/pages/chapters/index.ts
@@ -52,9 +52,29 @@ const data: IChapterData[] = [
             "Universal Robot Description Format (URDF)",
         ],
     },
-    // 아직 집필 전인 후속 챕터 — 사이드바/랜딩에서 dim 처리로 로드맵을 보여준다.
-    {chapter: 5, title: "Velocity Kinematics and Statics"},
-    {chapter: 6, title: "Inverse Kinematics"},
+    {
+        chapter: 5,
+        title: "Velocity Kinematics and Statics",
+        contents: lazy(() => import("./Chapter5")),
+        sections: [
+            "Manipulator Jacobian",
+            "Space and Body Jacobian",
+            "Statics of Open Chains",
+            "Singularities",
+            "Manipulability and Force Ellipsoids",
+        ],
+    },
+    {
+        chapter: 6,
+        title: "Inverse Kinematics",
+        contents: lazy(() => import("./Chapter6")),
+        sections: [
+            "Inverse Kinematics",
+            "Analytic Inverse Kinematics",
+            "Numerical Inverse Kinematics",
+            "Inverse Velocity Kinematics",
+        ],
+    },
 ]
 
 export default data.sort((a, b) => a.chapter - b.chapter)


### PR DESCRIPTION
Adds the next two chapters of the *Modern Robotics* study notes, following the existing per-chapter **teach-visually** convention (an interactive figure per key concept, wrapped in `CanvasFigure` and reusing the shared 2D/3D scaffolding).

## Chapter 5 — Velocity Kinematics and Statics
Sections: Manipulator Jacobian · Space and Body Jacobian · Statics of Open Chains · Singularities · Manipulability and Force Ellipsoids.

- **JacobianColumns** (Konva, interactive) — sliders drive a 2R arm; the two arrows at the tip *are* the Jacobian columns `J₁`, `J₂`. They align and `det J = L₁L₂ sinθ₂ → 0` at a singularity.
- **ManipulabilityEllipse** (Konva, interactive) — the manipulability ellipse stretches with the pose and collapses to a segment at a singularity (`ℓ_max/ℓ_min` readout); a checkbox overlays the reciprocal-axis **force ellipse**.

## Chapter 6 — Inverse Kinematics
Sections: Inverse Kinematics · Analytic Inverse Kinematics · Numerical Inverse Kinematics · Inverse Velocity Kinematics.

- **AnalyticIK2R** (Konva, drag) — drag the target through the workspace annulus to watch the closed-form **lefty/righty** solutions track it (both vanish outside the annulus).
- **NewtonRaphsonIK** (Konva, step) — step a trust-region-limited Newton iteration and watch the tip converge to a **draggable goal**, with the tip trace and `‖error‖` readout.

## Refactor (first commit)
Extracts the planar-arm math (`planarFk`, `jacobian2R`, `manipulabilityEllipse`, `ik2R`) into `libs/planarArm.ts` and rewires Chapter 4's `PlanarChain3R` to use the shared `planarFk` — removes the duplicated forward-kinematics loop so all planar figures share one source.

## Verification
- `yarn build` ✅ · `tsc --noEmit` ✅ (0 errors).
- Ran the dev server and drove `?chapter=5` and `?chapter=6`: all four figures render and react, Newton–Raphson converges to `‖error‖ = 0` and marks *converged*, force-ellipse toggle and analytic-IK solutions update live — **0 console errors**.
- Colors are theme-aware via `useCanvasColors()`; only semantic overlay hues are fixed and read in both light/dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
