### PR TITLE
ci(pages): deploy via GitHub Actions Pages instead of doc branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,39 +5,51 @@ on:
     branches:
       - main  # main 브랜치에 푸시될 때마다 실행됩니다.
 
+# Pages 배포에 필요한 최소 권한 (OIDC 토큰 포함)
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 배포는 동시에 하나만 — 진행 중 배포는 유지하고 대기 중인 것만 최신으로 교체해 경합을 없앤다.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'  # Node.js 버전 설정
-
-      - name: Install yarn
-        run: |
-          npm install --global yarn
+          node-version: '18'
+          cache: yarn
+          cache-dependency-path: document/yarn.lock
 
       - name: Install dependencies
-        run: |
-          yarn install
+        run: yarn install --frozen-lockfile
         working-directory: ./document
 
       - name: Build the project
-        run: |
-          yarn run build
+        run: yarn run build
         working-directory: ./document
 
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./document/dist
-          publish_branch: doc
+          path: ./document/dist
 
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 배경

배포가 `Deployment failed, try again later` 로 간헐 실패했다. 원인은 코드/빌드가 아니라 **두 개의 배포 메커니즘이 `doc` 브랜치를 매개로 체이닝된 구조**였다:

1. 커스텀 `deploy.yml` 이 `document/dist` 를 빌드해 `peaceiris/actions-gh-pages` 로 `doc` 브랜치에 push
2. GitHub legacy Pages 빌드(`pages-build-deployment`)가 `doc` 브랜치를 받아 배포

PR 이 짧은 간격으로 머지되면 `doc` 브랜치 배포가 연달아 트리거되어 GitHub Pages 측에서 경합/일시 실패가 발생했다.

## 변경

- `peaceiris/actions-gh-pages` (push-to-`doc`) → 공식 `actions/upload-pages-artifact` + `actions/deploy-pages` 파이프라인
- `concurrency: { group: pages, cancel-in-progress: false }` 로 배포 직렬화
- 최소 권한(`pages: write`, `id-token: write`) 명시, actions 버전 `v4` 로 갱신, yarn 캐시 추가

## 배포 설정 (머지 전후)

Pages source 를 **Branch(`doc`) → GitHub Actions** 로 전환 필요 (`build_type: workflow`). 머지와 함께 적용한다.

## 후속 정리

전환 후 `doc` 브랜치는 더 이상 쓰이지 않으므로 삭제 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)