### PR TITLE
feat(chapters): add Chapter 7-9 (closed chains, dynamics, trajectory generation)

### DIFF
--- a/document/src/components/pages/chapter7/FourBarLinkage.tsx
+++ b/document/src/components/pages/chapter7/FourBarLinkage.tsx
@@ -1,0 +1,227 @@
+import {useMemo, useState} from "react";
+import {Circle, Circle as KCircle, Layer, Line, Line as KLine, Rect, Stage, Text, Text as KText} from "react-konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap} from "../../../libs/konvaUtils";
+import {useCanvasColors} from "../../../libs/useTheme";
+
+// 4절 링크(four-bar): 가장 단순한 폐연쇄 — 루프 하나, C-space 1자유도.
+// 지면 P0—P3 를 기준으로 크랭크 P0→A 를 슬라이더 θ 로 돌리면, 커플러 b 와 로커 c 가
+// 그리는 원 두 개의 교점으로 B 가 결정된다(loop closure). 교점이 둘 → 두 조립 모드(가지).
+// change-point(평행사변형) 링크 길이라 두 가지가 θ=0,π 에서 만나며 — 그 지점이
+// configuration-space singularity(bifurcation)다.
+const GROUND = 3;       // P0—P3 지면 길이
+const CRANK = 2;        // P0→A 입력 크랭크
+const COUPLER = 3;      // A→B 커플러
+const ROCKER = 2;       // P3→B 출력 로커
+const RESOLUTION = 0.05;
+
+// P0/P3 를 원점 기준 좌우 대칭으로 두어 그림을 가운데 정렬한다.
+const P0 = {x: -GROUND / 2, y: 0};
+const P3 = {x: GROUND / 2, y: 0};
+
+const ROCKER_COLOR = "#f2a63a";
+
+interface P {
+    x: number;
+    y: number;
+}
+
+interface Solution {
+    reachable: boolean;
+    B: P;
+    psi: number;
+    // 두 교점 사이 거리의 절반(원-원 수직 오프셋). 0 이면 두 가지가 합쳐지는 특이점.
+    h: number;
+}
+
+// 원(A,COUPLER) 과 원(P3,ROCKER) 의 교점. sign 이 두 조립 모드를 고른다.
+const solveFourBar = (theta: number, sign: number): Solution => {
+    const A = {x: P0.x + CRANK * Math.cos(theta), y: P0.y + CRANK * Math.sin(theta)};
+    const dx = P3.x - A.x, dy = P3.y - A.y;
+    const D = Math.hypot(dx, dy);
+    // 두 원이 만나지 않으면(너무 멀거나 한쪽이 다른쪽 안) 그 θ 에서는 조립 불가.
+    if (D > COUPLER + ROCKER + 1e-9 || D < Math.abs(COUPLER - ROCKER) - 1e-9 || D < 1e-9) {
+        return {reachable: false, B: A, psi: 0, h: 0};
+    }
+    const ell = (COUPLER * COUPLER - ROCKER * ROCKER + D * D) / (2 * D);
+    const h = Math.sqrt(Math.max(0, COUPLER * COUPLER - ell * ell));
+    const bx = A.x + (ell / D) * dx, by = A.y + (ell / D) * dy;
+    const B = {x: bx + sign * (h / D) * -dy, y: by + sign * (h / D) * dx};
+    return {reachable: true, B, psi: Math.atan2(B.y - P3.y, B.x - P3.x), h};
+};
+
+// C-space 미니플롯 좌표계.
+const CS_W = 320, CS_H = 150, CS_PAD = 24;
+const csX = (theta: number) => CS_PAD + (theta / (2 * Math.PI)) * (CS_W - 2 * CS_PAD);
+const csY = (psi: number) => CS_PAD + (1 - (psi + Math.PI) / (2 * Math.PI)) * (CS_H - 2 * CS_PAD);
+
+// 한 가지(sign)의 ψ(θ) 곡선을 flat 배열로. 도달 불가 구간은 끊어 여러 세그먼트로 나눈다.
+const branchSegments = (sign: number): number[][] => {
+    const segments: number[][] = [];
+    let cur: number[] = [];
+    const N = 240;
+    for (let i = 0; i <= N; i++) {
+        const theta = (i / N) * 2 * Math.PI;
+        const s = solveFourBar(theta, sign);
+        if (!s.reachable) {
+            if (cur.length) segments.push(cur);
+            cur = [];
+            continue;
+        }
+        cur.push(csX(theta), csY(s.psi));
+    }
+    if (cur.length) segments.push(cur);
+    return segments;
+};
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const FourBarScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [theta, setTheta] = useState(1.1);
+    const [sign, setSign] = useState(1);
+
+    const sol = useMemo(() => solveFourBar(theta, sign), [theta, sign]);
+    const branches = useMemo(() => ({pos: branchSegments(1), neg: branchSegments(-1)}), []);
+
+    // 두 가지가 만나는 bifurcation: h≈0 인 θ. change-point 링크에선 θ=0, π 에서 발생.
+    const bifurcations = useMemo(() => {
+        const pts: {theta: number; psi: number}[] = [];
+        [0, Math.PI].forEach((th) => {
+            const s = solveFourBar(th, 1);
+            if (s.reachable) pts.push({theta: th, psi: s.psi});
+        });
+        return pts;
+    }, []);
+
+    const toPx = (p: P) => globalToMap(width, height, p.x, p.y, RESOLUTION);
+    const p0 = toPx(P0), p3 = toPx(P3);
+    const A = {x: P0.x + CRANK * Math.cos(theta), y: P0.y + CRANK * Math.sin(theta)};
+    const aPx = toPx(A);
+    const bPx = toPx(sol.B);
+
+    const singular = Math.abs(sol.h) < 0.06;
+    const curSeg = sign > 0 ? branches.pos : branches.neg;
+    const otherSeg = sign > 0 ? branches.neg : branches.pos;
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {/* 지면 P0—P3 */}
+                <Line points={[p0.x, p0.y, p3.x, p3.y]} stroke={colors.muted} strokeWidth={3}
+                      dash={[6, 5]} lineCap="round"/>
+                {sol.reachable && (
+                    <>
+                        {/* 커플러 A—B */}
+                        <Line points={[aPx.x, aPx.y, bPx.x, bPx.y]} stroke={colors.text} strokeWidth={4}
+                              lineCap="round"/>
+                        {/* 로커 P3—B */}
+                        <Line points={[p3.x, p3.y, bPx.x, bPx.y]} stroke={ROCKER_COLOR} strokeWidth={4}
+                              lineCap="round"/>
+                    </>
+                )}
+                {/* 크랭크 P0—A (항상 유효) */}
+                <Line points={[p0.x, p0.y, aPx.x, aPx.y]} stroke={colors.accent} strokeWidth={4}
+                      lineCap="round"/>
+                {/* 지면 고정 관절 */}
+                <Circle x={p0.x} y={p0.y} radius={6} fill={colors.text}/>
+                <Circle x={p3.x} y={p3.y} radius={6} fill={colors.text}/>
+                {/* 가동 관절 A, B */}
+                <Circle x={aPx.x} y={aPx.y} radius={5} fill={colors.surface} stroke={colors.accent}
+                        strokeWidth={2}/>
+                {sol.reachable && (
+                    <Circle x={bPx.x} y={bPx.y} radius={5} fill={colors.surface}
+                            stroke={singular ? colors.muted : ROCKER_COLOR} strokeWidth={2}/>
+                )}
+                <Text x={aPx.x + 8} y={aPx.y - 16} text="A" fontSize={13} fontStyle="bold" fill={colors.accent}/>
+                {sol.reachable && (
+                    <Text x={bPx.x + 8} y={bPx.y - 16} text="B" fontSize={13} fontStyle="bold" fill={ROCKER_COLOR}/>
+                )}
+            </CoordinateSystem>
+
+            <div className="w-full flex flex-col gap-1 text-xs text-muted">
+                <label className="flex items-center gap-2">
+                    <span className="w-8 shrink-0">θ</span>
+                    <input
+                        type="range"
+                        min={0}
+                        max={2 * Math.PI}
+                        step={0.01}
+                        value={theta}
+                        onChange={(e) => setTheta(parseFloat(e.target.value))}
+                        className="w-full accent-[var(--accent)]"
+                        aria-label="driving crank angle theta"
+                    />
+                    <span className="w-12 shrink-0 text-right tabular-nums">
+                        {Math.round((theta * 180) / Math.PI)}°
+                    </span>
+                </label>
+                <div className="flex items-center justify-center gap-3 pt-0.5">
+                    <button
+                        type="button"
+                        onClick={() => setSign((s) => -s)}
+                        className="px-2 py-0.5 rounded border border-border hover:bg-surface"
+                    >
+                        assembly branch: {sign > 0 ? "▲" : "▼"}
+                    </button>
+                    <span>
+                        ψ = {sol.reachable ? `${Math.round((sol.psi * 180) / Math.PI)}°` : "—"}{" "}
+                        {singular
+                            ? <span className="text-[var(--accent)] font-semibold">· bifurcation (branches meet)</span>
+                            : <span>· regular</span>}
+                    </span>
+                </div>
+            </div>
+
+            {/* C-space 패널: ψ vs θ. 현재 가지는 진하게, 반대 가지는 흐리게; 두 가지의 만남점이 특이점. */}
+            <Stage width={CS_W} height={CS_H} className="bg-surface border border-border rounded-lg overflow-hidden">
+                <Layer>
+                    <Rect x={CS_PAD} y={CS_PAD} width={CS_W - 2 * CS_PAD} height={CS_H - 2 * CS_PAD}
+                          stroke={colors.border} strokeWidth={1}/>
+                    <KText x={CS_PAD} y={CS_H - CS_PAD + 4} text="θ 0" fontSize={11} fill={colors.muted}/>
+                    <KText x={CS_W - CS_PAD - 18} y={CS_H - CS_PAD + 4} text="2π" fontSize={11} fill={colors.muted}/>
+                    <KText x={2} y={CS_PAD - 6} text="ψ +π" fontSize={11} fill={colors.muted}/>
+                    <KText x={4} y={CS_H - CS_PAD - 10} text="−π" fontSize={11} fill={colors.muted}/>
+                    {otherSeg.map((seg, i) => (
+                        <KLine key={`other-${i}`} points={seg} stroke={colors.muted} strokeWidth={1.5}
+                               dash={[4, 4]} opacity={0.6}/>
+                    ))}
+                    {curSeg.map((seg, i) => (
+                        <KLine key={`cur-${i}`} points={seg} stroke={colors.accent} strokeWidth={2.5}/>
+                    ))}
+                    {bifurcations.map((b, i) => (
+                        <KCircle key={`bif-${i}`} x={csX(b.theta)} y={csY(b.psi)} radius={4}
+                                 stroke={colors.text} strokeWidth={1.5} fill={colors.surface}/>
+                    ))}
+                    {sol.reachable && (
+                        <KCircle x={csX(theta)} y={csY(sol.psi)} radius={5} fill={colors.accent}/>
+                    )}
+                    <KText x={CS_W - CS_PAD - 74} y={4} text="bifurcation ○" fontSize={11} fill={colors.muted}/>
+                </Layer>
+            </Stage>
+        </div>
+    );
+};
+
+const FourBarLinkage = () => {
+    return <CanvasFigure
+        label="four-bar linkage · sweep θ; the C-space panel shows ψ(θ) and its bifurcations"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<FourBarScene width={460} height={460}/>}
+    >
+        <FourBarScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default FourBarLinkage;

--- a/document/src/components/pages/chapter7/RPRParallel.tsx
+++ b/document/src/components/pages/chapter7/RPRParallel.tsx
@@ -1,0 +1,138 @@
+import {useMemo, useState} from "react";
+import {Circle, Line, Text} from "react-konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap} from "../../../libs/konvaUtils";
+import {useCanvasColors} from "../../../libs/useTheme";
+
+// 3-RPR 평면 병렬기구: 고정 삼각형 aᵢ 와 가동 플랫폼 삼각형 bᵢ 를 3개의 다리로 잇는다.
+// 각 다리는 P(수동)–R(수동)–P(능동, 길이 sᵢ)로, 프리즘 관절 sᵢ 만 구동한다.
+// 포즈 (pₓ,p_y,φ) 를 주면 Bᵢ = p + R(φ)bᵢ 로 다리 길이 sᵢ = ‖Bᵢ−aᵢ‖ 가 곧바로 나온다 —
+// 역기구학은 단순 대입. (반대로 sᵢ 로부터 포즈를 푸는 정기구학은 6차 다항식이 된다.)
+const RESOLUTION = 0.03;
+
+// 고정 베이스 관절 aᵢ ({s} 좌표).
+const A_BASE = [
+    {x: -2, y: -1.5},
+    {x: 2, y: -1.5},
+    {x: 0, y: 2.2},
+];
+
+// 플랫폼 본체 관절 bᵢ ({b} 좌표) — 작은 삼각형.
+const B_BODY = [
+    {x: -0.7, y: -0.5},
+    {x: 0.7, y: -0.5},
+    {x: 0, y: 0.8},
+];
+
+const PLATFORM_COLOR = "#f2a63a";
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const RPRScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [pose, setPose] = useState({px: 0, py: 0, phi: 0});
+
+    const {legs, worldB} = useMemo(() => {
+        const c = Math.cos(pose.phi), s = Math.sin(pose.phi);
+        // Bᵢ = p + R(φ) bᵢ, 다리 길이 sᵢ = ‖Bᵢ − aᵢ‖.
+        const worldB = B_BODY.map((b) => ({
+            x: pose.px + c * b.x - s * b.y,
+            y: pose.py + s * b.x + c * b.y,
+        }));
+        const legs = worldB.map((B, i) => Math.hypot(B.x - A_BASE[i].x, B.y - A_BASE[i].y));
+        return {legs, worldB};
+    }, [pose]);
+
+    const toPx = (p: {x: number; y: number}) => globalToMap(width, height, p.x, p.y, RESOLUTION);
+    const aPx = A_BASE.map(toPx);
+    const bPx = worldB.map(toPx);
+    const platformPts = bPx.flatMap((p) => [p.x, p.y]);
+    const centerPx = toPx({x: pose.px, y: pose.py});
+
+    const setField = (k: "px" | "py" | "phi", v: number) =>
+        setPose((prev) => ({...prev, [k]: v}));
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {/* 세 다리 aᵢ→Bᵢ (능동 프리즘 관절) */}
+                {aPx.map((a, i) => (
+                    <Line key={`leg-${i}`} points={[a.x, a.y, bPx[i].x, bPx[i].y]}
+                          stroke={colors.text} strokeWidth={5} lineCap="round" opacity={0.55}/>
+                ))}
+                {/* 가동 플랫폼 삼각형: 반투명 채움 + 뚜렷한 외곽선 */}
+                <Line points={platformPts} closed fill={PLATFORM_COLOR} opacity={0.18} listening={false}/>
+                <Line points={platformPts} closed stroke={PLATFORM_COLOR} strokeWidth={3}/>
+                {/* 고정 베이스 관절 */}
+                {aPx.map((a, i) => (
+                    <Circle key={`a-${i}`} x={a.x} y={a.y} radius={7} fill={colors.text}/>
+                ))}
+                {aPx.map((a, i) => (
+                    <Text key={`al-${i}`} x={a.x + 9} y={a.y - 6} text={`a${i + 1}`} fontSize={12}
+                          fill={colors.muted}/>
+                ))}
+                {/* 플랫폼 관절 Bᵢ */}
+                {bPx.map((b, i) => (
+                    <Circle key={`b-${i}`} x={b.x} y={b.y} radius={5} fill={colors.surface}
+                            stroke={PLATFORM_COLOR} strokeWidth={2}/>
+                ))}
+                <Circle x={centerPx.x} y={centerPx.y} radius={3} fill={PLATFORM_COLOR}/>
+            </CoordinateSystem>
+
+            <div className="w-full flex flex-col gap-1 text-xs text-muted">
+                <label className="flex items-center gap-2">
+                    <span className="w-8 shrink-0">pₓ</span>
+                    <input type="range" min={-1.6} max={1.6} step={0.01} value={pose.px}
+                           onChange={(e) => setField("px", parseFloat(e.target.value))}
+                           className="w-full accent-[var(--accent)]" aria-label="platform x position"/>
+                    <span className="w-12 shrink-0 text-right tabular-nums">{pose.px.toFixed(2)}</span>
+                </label>
+                <label className="flex items-center gap-2">
+                    <span className="w-8 shrink-0">p_y</span>
+                    <input type="range" min={-1.2} max={1.4} step={0.01} value={pose.py}
+                           onChange={(e) => setField("py", parseFloat(e.target.value))}
+                           className="w-full accent-[var(--accent)]" aria-label="platform y position"/>
+                    <span className="w-12 shrink-0 text-right tabular-nums">{pose.py.toFixed(2)}</span>
+                </label>
+                <label className="flex items-center gap-2">
+                    <span className="w-8 shrink-0">φ</span>
+                    <input type="range" min={-Math.PI / 2} max={Math.PI / 2} step={0.01} value={pose.phi}
+                           onChange={(e) => setField("phi", parseFloat(e.target.value))}
+                           className="w-full accent-[var(--accent)]" aria-label="platform orientation phi"/>
+                    <span className="w-12 shrink-0 text-right tabular-nums">
+                        {Math.round((pose.phi * 180) / Math.PI)}°
+                    </span>
+                </label>
+                <div className="text-center pt-1">
+                    inverse kinematics:{" "}
+                    <span className="font-semibold" style={{color: PLATFORM_COLOR}}>
+                        s₁={legs[0].toFixed(2)} · s₂={legs[1].toFixed(2)} · s₃={legs[2].toFixed(2)}
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const RPRParallel = () => {
+    return <CanvasFigure
+        label="3-RPR parallel mechanism · leg lengths follow directly from the platform pose"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<RPRScene width={460} height={460}/>}
+    >
+        <RPRScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default RPRParallel;

--- a/document/src/components/pages/chapter8/MassMatrixEllipse.tsx
+++ b/document/src/components/pages/chapter8/MassMatrixEllipse.tsx
@@ -1,0 +1,147 @@
+import {useMemo, useState} from "react";
+import {Circle, Ellipse, Line, Text} from "react-konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {planarFk} from "../../../libs/planarArm";
+import {useCanvasColors} from "../../../libs/useTheme";
+import {massMatrix2R, TWO_R} from "./twoRModel";
+
+// 관성의 자세 의존성: 자세 θ 에서 단위 관절토크 원 {‖u‖=1} 을 M⁻¹ 로 사상하면 관절가속도 타원
+// {M⁻¹u} 이 된다. 둥근 타원 = 등방적(가속 쉬움), 늘어난 타원 = 방향 의존·커플링 강함.
+// 팔을 접으면(θ2→π) 타원이 둥글어지고 펴면(θ2→0) 가늘어진다.
+const {l1: L1, l2: L2} = TWO_R;
+// 확장 자세(θ2→0)에서 가속도 타원의 장축이 커지므로, 그때도 캔버스 안에 담기도록 축척을 잡는다.
+const RESOLUTION = 0.025;
+const SCALE = 1 / RESOLUTION;
+// 코너에 그리는 팔 자세 미니어처(가속도 평면과 좌표가 다르므로 픽셀 단위로 따로 그린다).
+const ARM_ORIGIN = {x: 42, y: 42};
+const ARM_SCALE = 15;
+
+const degrees = (rad: number) => Math.round((rad * 180) / Math.PI);
+
+interface Eig {
+    major: number;
+    minor: number;
+    angle: number;
+}
+
+// 대칭 2×2 [[a,b],[b,c]] 의 고유분해. M⁻¹ 은 SPD 라 고윳값이 곧 반축 길이(원→타원 사상)다.
+const symEig = (a: number, b: number, c: number): Eig => {
+    const mid = (a + c) / 2;
+    const half = Math.sqrt(Math.max(0, ((a - c) / 2) ** 2 + b * b));
+    return {major: mid + half, minor: Math.max(0, mid - half), angle: 0.5 * Math.atan2(2 * b, a - c)};
+};
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const MassMatrixScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [theta, setTheta] = useState<[number, number]>([0.6, 1.6]);
+
+    const {m11, m12, m22, eig, det} = useMemo(() => {
+        const [a, b, c] = massMatrix2R(theta[1]);
+        const det = a * c - b * b;
+        // M⁻¹ = (1/det)[[M22, −M12], [−M12, M11]] — 대칭. 이 행렬의 고유분해가 가속도 타원을 준다.
+        // 점질량 2R 은 항상 SPD 라 det>0 이지만, 0 근처에서의 NaN 을 막는 안전장치를 둔다.
+        const inv = Math.abs(det) < 1e-9 ? 0 : 1 / det;
+        return {m11: a, m12: b, m22: c, det, eig: symEig(c * inv, -b * inv, a * inv)};
+    }, [theta]);
+
+    const rotationDeg = (-eig.angle * 180) / Math.PI;
+    const center = {x: width / 2, y: height / 2};
+    const ratio = eig.minor > 1e-6 ? eig.major / eig.minor : Infinity;
+
+    // 코너 미니어처 팔: 좌표 눈금과 무관한 자체 축척으로 자세만 보여준다.
+    const armPx = planarFk(theta, [L1, L2]).points.map((p) => ({
+        x: ARM_ORIGIN.x + p.x * ARM_SCALE,
+        y: ARM_ORIGIN.y - p.y * ARM_SCALE,
+    }));
+
+    const setJoint = (i: number, v: number) =>
+        setTheta((prev) => {
+            const next = [...prev] as [number, number];
+            next[i] = v;
+            return next;
+        });
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {/* 입력: 단위 관절토크 원 ‖u‖=1 */}
+                <Circle x={center.x} y={center.y} radius={SCALE} stroke={colors.muted} strokeWidth={1.5}
+                        dash={[5, 4]}/>
+                {/* 출력: 관절가속도 타원 {M⁻¹u} */}
+                <Ellipse
+                    x={center.x}
+                    y={center.y}
+                    radiusX={Math.max(eig.major * SCALE, 1)}
+                    radiusY={Math.max(eig.minor * SCALE, 1)}
+                    rotation={rotationDeg}
+                    fill={colors.accent}
+                    opacity={0.28}
+                    stroke={colors.accent}
+                    strokeWidth={2}
+                />
+                <Text x={center.x + SCALE + 6} y={center.y - 4} text="θ̈₁" fontSize={13} fill={colors.muted}/>
+                <Text x={center.x + 6} y={center.y - SCALE - 16} text="θ̈₂" fontSize={13} fill={colors.muted}/>
+
+                {/* 코너 팔 자세 */}
+                {armPx.slice(0, -1).map((p, i) => (
+                    <Line key={`arm-${i}`} points={[p.x, p.y, armPx[i + 1].x, armPx[i + 1].y]}
+                          stroke={colors.text} strokeWidth={3} lineCap="round" opacity={0.6}/>
+                ))}
+                {armPx.map((p, i) => (
+                    <Circle key={`arm-j-${i}`} x={p.x} y={p.y} radius={3} fill={colors.text} opacity={0.6}/>
+                ))}
+                <Text x={ARM_ORIGIN.x - 12} y={ARM_ORIGIN.y - 30} text="posture" fontSize={11} fill={colors.muted}/>
+            </CoordinateSystem>
+            <div className="w-full flex flex-col gap-1 text-xs text-muted">
+                {[0, 1].map((i) => (
+                    <label key={i} className="flex items-center gap-2">
+                        <span className="w-8 shrink-0">θ{i + 1}</span>
+                        <input
+                            type="range"
+                            min={-Math.PI}
+                            max={Math.PI}
+                            step={0.01}
+                            value={theta[i]}
+                            onChange={(e) => setJoint(i, parseFloat(e.target.value))}
+                            className="w-full accent-[var(--accent)]"
+                            aria-label={`joint angle theta ${i + 1}`}
+                        />
+                        <span className="w-12 shrink-0 text-right tabular-nums">{degrees(theta[i])}°</span>
+                    </label>
+                ))}
+                <div className="flex items-center justify-between pt-1 tabular-nums">
+                    <span>
+                        M = [{m11.toFixed(2)}, {m12.toFixed(2)}; {m12.toFixed(2)}, {m22.toFixed(2)}]
+                    </span>
+                    <span>κ = {ratio === Infinity ? "∞" : ratio.toFixed(2)}</span>
+                </div>
+                <div className="text-center">det&nbsp;M = {det.toFixed(2)}</div>
+            </div>
+        </div>
+    );
+};
+
+const MassMatrixEllipse = () => {
+    return <CanvasFigure
+        label="acceleration ellipse · configuration-dependence of inertia"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<MassMatrixScene width={460} height={460}/>}
+    >
+        <MassMatrixScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default MassMatrixEllipse;

--- a/document/src/components/pages/chapter8/TwoRDynamics.tsx
+++ b/document/src/components/pages/chapter8/TwoRDynamics.tsx
@@ -1,0 +1,270 @@
+import {useEffect, useRef, useState} from "react";
+import {Circle, Line} from "react-konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap} from "../../../libs/konvaUtils";
+import {planarFk} from "../../../libs/planarArm";
+import {useCanvasColors} from "../../../libs/useTheme";
+import {massMatrix2R, TWO_R} from "./twoRModel";
+
+// 2R 팔의 순방향 동역학 실시간 시뮬레이터(이 장의 대표 그림). 책의 점질량 모델을 그대로 쓴다:
+// τ = M(θ)θ̈ + c(θ,θ̇) + g(θ) 를 θ̈ = M⁻¹(τ − c − g) 로 풀어 준-암시적(symplectic) Euler 로 적분한다.
+// τ=0·중력 on 이면 double pendulum — 에너지는 보존되지만 카오스적이라 초기조건에 민감하다.
+const {l1: L1, l2: L2, m1: M1, m2: M2, g: G} = TWO_R;
+const RESOLUTION = 0.02;
+// 물리를 프레임률과 분리한다: 고정 서브스텝으로 적분하고 프레임 dt 를 클램프해 spiral-of-death 를 막는다.
+const SUB_DT = 0.004;
+const MAX_FRAME_DT = 0.05;
+const MAX_SUBSTEPS = 400;
+const TRAIL_MAX = 90;
+// 초기 자세: 수직에서 약간 벗어나 있어 중력만으로도 흔들리기 시작한다.
+const INIT_THETA: [number, number] = [Math.PI / 2 + 0.4, 0.3];
+
+// 원심(θ̇ᵢ²)·코리올리(θ̇ᵢθ̇ⱼ) 항.
+const coriolis = (t2: number, d1: number, d2: number): [number, number] => {
+    const s2 = Math.sin(t2);
+    return [
+        -M2 * L1 * L2 * s2 * (2 * d1 * d2 + d2 * d2),
+        M2 * L1 * L2 * d1 * d1 * s2,
+    ];
+};
+
+// 중력항 g(θ). 중력이 꺼져 있으면 0.
+const gravityVec = (t1: number, t2: number, on: boolean): [number, number] => {
+    if (!on) return [0, 0];
+    const c1 = Math.cos(t1), c12 = Math.cos(t1 + t2);
+    return [
+        (M1 + M2) * L1 * G * c1 + M2 * G * L2 * c12,
+        M2 * G * L2 * c12,
+    ];
+};
+
+// θ̈ = M⁻¹(τ − c − g). det≈0 이면(수치적 안전장치) 가속도 0 을 반환한다.
+const forwardDynamics = (
+    theta: [number, number],
+    dot: [number, number],
+    tau: [number, number],
+    gravity: boolean,
+): [number, number] => {
+    const [m11, m12, m22] = massMatrix2R(theta[1]);
+    const [c1, c2] = coriolis(theta[1], dot[0], dot[1]);
+    const [g1, g2] = gravityVec(theta[0], theta[1], gravity);
+    const r1 = tau[0] - c1 - g1;
+    const r2 = tau[1] - c2 - g2;
+    const det = m11 * m22 - m12 * m12;
+    if (Math.abs(det) < 1e-9) return [0, 0];
+    return [(m22 * r1 - m12 * r2) / det, (-m12 * r1 + m11 * r2) / det];
+};
+
+const energy = (theta: [number, number], dot: [number, number], gravity: boolean): number => {
+    const [m11, m12, m22] = massMatrix2R(theta[1]);
+    const ke = 0.5 * (m11 * dot[0] * dot[0] + 2 * m12 * dot[0] * dot[1] + m22 * dot[1] * dot[1]);
+    if (!gravity) return ke;
+    const {points} = planarFk(theta, [L1, L2]);
+    return ke + M1 * G * points[1].y + M2 * G * points[2].y;
+};
+
+interface Ctrl {
+    tau: [number, number];
+    gravity: boolean;
+    gravComp: boolean;
+}
+
+interface RenderState {
+    theta: [number, number];
+    dot: [number, number];
+}
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const TwoRScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [tau, setTau] = useState<[number, number]>([0, 0]);
+    const [gravity, setGravity] = useState(true);
+    const [gravComp, setGravComp] = useState(false);
+    const [running, setRunning] = useState(true);
+    const [render, setRender] = useState<RenderState>({theta: [INIT_THETA[0], INIT_THETA[1]], dot: [0, 0]});
+
+    // 물리 상태는 ref 에 두어 프레임마다 setState 없이 적분한다. setState 는 렌더 갱신용으로만 쓴다.
+    const thetaRef = useRef<[number, number]>([INIT_THETA[0], INIT_THETA[1]]);
+    const dotRef = useRef<[number, number]>([0, 0]);
+    const trailRef = useRef<Array<{x: number; y: number}>>([]);
+    const rafRef = useRef<number | null>(null);
+    const lastRef = useRef<number | null>(null);
+    const accRef = useRef(0);
+
+    // 매 렌더마다 최신 컨트롤을 ref 로 넘겨 애니메이션 루프의 stale closure 를 피한다.
+    const ctrlRef = useRef<Ctrl>({tau, gravity, gravComp});
+    ctrlRef.current = {tau, gravity, gravComp};
+
+    const integrate = (h: number) => {
+        const th = thetaRef.current;
+        const dq = dotRef.current;
+        const {tau: uTau, gravity: gOn, gravComp: comp} = ctrlRef.current;
+        // 중력 보상: τ = g(θ) 를 더하면 중력이 상쇄되어 팔이 무중력처럼 뜬다.
+        let t1 = uTau[0], t2 = uTau[1];
+        if (gOn && comp) {
+            const [g1, g2] = gravityVec(th[0], th[1], true);
+            t1 += g1;
+            t2 += g2;
+        }
+        const [dd1, dd2] = forwardDynamics(th, dq, [t1, t2], gOn);
+        // 준-암시적 Euler: 먼저 속도를 갱신하고 그 속도로 위치를 갱신 → 진자에서 에너지 안정.
+        const nd1 = dq[0] + dd1 * h;
+        const nd2 = dq[1] + dd2 * h;
+        if (!Number.isFinite(nd1) || !Number.isFinite(nd2)) {
+            thetaRef.current = [INIT_THETA[0], INIT_THETA[1]];
+            dotRef.current = [0, 0];
+            trailRef.current = [];
+            return;
+        }
+        dotRef.current = [nd1, nd2];
+        thetaRef.current = [th[0] + nd1 * h, th[1] + nd2 * h];
+    };
+
+    useEffect(() => {
+        if (!running) return;
+        lastRef.current = null;
+        accRef.current = 0;
+        const frame = (now: number) => {
+            const last = lastRef.current ?? now;
+            lastRef.current = now;
+            let frameDt = (now - last) / 1000;
+            if (frameDt > MAX_FRAME_DT) frameDt = MAX_FRAME_DT;
+            accRef.current += frameDt;
+            let steps = 0;
+            while (accRef.current >= SUB_DT && steps < MAX_SUBSTEPS) {
+                integrate(SUB_DT);
+                accRef.current -= SUB_DT;
+                steps++;
+            }
+            const {points} = planarFk(thetaRef.current, [L1, L2]);
+            const tip = points[points.length - 1];
+            const trail = trailRef.current;
+            trail.push({x: tip.x, y: tip.y});
+            if (trail.length > TRAIL_MAX) trail.shift();
+            setRender({theta: [thetaRef.current[0], thetaRef.current[1]], dot: [dotRef.current[0], dotRef.current[1]]});
+            rafRef.current = requestAnimationFrame(frame);
+        };
+        rafRef.current = requestAnimationFrame(frame);
+        return () => {
+            if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+        };
+    }, [running]);
+
+    const reset = () => {
+        thetaRef.current = [INIT_THETA[0], INIT_THETA[1]];
+        dotRef.current = [0, 0];
+        trailRef.current = [];
+        accRef.current = 0;
+        lastRef.current = null;
+        setRender({theta: [INIT_THETA[0], INIT_THETA[1]], dot: [0, 0]});
+    };
+
+    const {points} = planarFk(render.theta, [L1, L2]);
+    const px = points.map((p) => globalToMap(width, height, p.x, p.y, RESOLUTION));
+    const trailPx = trailRef.current.flatMap((p) => {
+        const m = globalToMap(width, height, p.x, p.y, RESOLUTION);
+        return [m.x, m.y];
+    });
+    const massRadius = (m: number) => 5 + Math.sqrt(m) * 5;
+    const totalE = energy(render.theta, render.dot, gravity);
+
+    const setJointTau = (i: number, v: number) =>
+        setTau((prev) => {
+            const next = [...prev] as [number, number];
+            next[i] = v;
+            return next;
+        });
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                {trailPx.length >= 4 && (
+                    <Line points={trailPx} stroke={colors.accent} strokeWidth={1.5} opacity={0.3} lineCap="round"/>
+                )}
+                {px.slice(0, -1).map((p, i) => (
+                    <Line key={`link-${i}`} points={[p.x, p.y, px[i + 1].x, px[i + 1].y]}
+                          stroke={colors.text} strokeWidth={4} lineCap="round" opacity={0.75}/>
+                ))}
+                {px.slice(0, -1).map((p, i) => (
+                    <Circle key={`joint-${i}`} x={p.x} y={p.y} radius={5} fill={colors.surface}
+                            stroke={colors.text} strokeWidth={2}/>
+                ))}
+                {/* 점질량: 질량 크기에 비례한 반지름의 채워진 원 */}
+                <Circle x={px[1].x} y={px[1].y} radius={massRadius(M1)} fill={colors.accent} opacity={0.85}/>
+                <Circle x={px[2].x} y={px[2].y} radius={massRadius(M2)} fill={colors.accent} opacity={0.85}/>
+            </CoordinateSystem>
+            <div className="w-full flex flex-col gap-1 text-xs text-muted">
+                <div className="flex items-center gap-2">
+                    <button type="button" onClick={() => setRunning((r) => !r)}
+                            className="px-3 py-1 rounded-md bg-[var(--accent)] text-white font-semibold">
+                        {running ? "Pause" : "Play"}
+                    </button>
+                    <button type="button" onClick={reset}
+                            className="px-3 py-1 rounded-md border border-border">
+                        Reset
+                    </button>
+                    <label className="flex items-center gap-1.5 cursor-pointer ml-auto">
+                        <input type="checkbox" checked={gravity}
+                               onChange={(e) => setGravity(e.target.checked)}
+                               className="accent-[var(--accent)]"/>
+                        <span>gravity</span>
+                    </label>
+                    <label className="flex items-center gap-1.5 cursor-pointer"
+                           style={{opacity: gravity ? 1 : 0.4}}>
+                        <input type="checkbox" checked={gravComp} disabled={!gravity}
+                               onChange={(e) => setGravComp(e.target.checked)}
+                               className="accent-[var(--accent)]"/>
+                        <span>grav. comp.</span>
+                    </label>
+                </div>
+                {[0, 1].map((i) => (
+                    <label key={i} className="flex items-center gap-2">
+                        <span className="w-8 shrink-0">τ{i + 1}</span>
+                        <input
+                            type="range"
+                            min={-20}
+                            max={20}
+                            step={0.5}
+                            value={tau[i]}
+                            onChange={(e) => setJointTau(i, parseFloat(e.target.value))}
+                            className="w-full accent-[var(--accent)]"
+                            aria-label={`joint torque tau ${i + 1}`}
+                        />
+                        <span className="w-14 shrink-0 text-right tabular-nums">{tau[i].toFixed(1)} N·m</span>
+                    </label>
+                ))}
+                <div className="text-center pt-1 tabular-nums">
+                    {running
+                        ? <span className="text-[var(--accent)] font-semibold">running</span>
+                        : <span>paused</span>}{" "}
+                    · E = {totalE.toFixed(2)} J
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const TwoRDynamics = () => {
+    return <CanvasFigure
+        label="forward dynamics · a 2R arm as a double pendulum"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<TwoRScene width={460} height={460}/>}
+    >
+        <TwoRScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default TwoRDynamics;

--- a/document/src/components/pages/chapter8/twoRModel.ts
+++ b/document/src/components/pages/chapter8/twoRModel.ts
@@ -1,0 +1,13 @@
+// Chapter 8 의 두 그림(동역학 시뮬레이터·질량행렬 타원)이 같은 팔을 그리도록 팔 파라미터와
+// 점질량 2R 질량행렬을 한 곳에서 정의한다 — 한쪽 상수만 바뀌면 두 그림이 서로 다른 팔이 되기 때문이다.
+export const TWO_R = {l1: 1.4, l2: 1.1, m1: 1, m2: 1, g: 9.81} as const;
+
+// 점질량 2R 팔의 대칭 질량행렬 [M11, M12, M22]. M12 는 두 관절을 결합한다(관성 커플링).
+export const massMatrix2R = (t2: number): [number, number, number] => {
+    const {l1, l2, m1, m2} = TWO_R;
+    const c2 = Math.cos(t2);
+    const m11 = m1 * l1 * l1 + m2 * (l1 * l1 + 2 * l1 * l2 * c2 + l2 * l2);
+    const m12 = m2 * (l1 * l2 * c2 + l2 * l2);
+    const m22 = m2 * l2 * l2;
+    return [m11, m12, m22];
+};

--- a/document/src/components/pages/chapter9/TimeScalingProfiles.tsx
+++ b/document/src/components/pages/chapter9/TimeScalingProfiles.tsx
@@ -1,0 +1,319 @@
+import {useEffect, useMemo, useRef, useState} from "react";
+import {Circle, Layer, Line, Stage, Text} from "react-konva";
+import CanvasFigure from "../../CanvasFigure";
+import {useCanvasColors, type CanvasColors} from "../../../libs/useTheme";
+
+// 시간 스케일링 s(t) 세 종류(cubic·quintic·trapezoidal)를 s, ṡ, s̈ 세 그래프로 비교한다.
+// Play 를 누르면 path θ(s) 위의 점이 s(t) 속도로 움직여, cubic/quintic 은 가운데서 빠르고
+// trapezoidal 은 등속 coast 구간을 가진다는 차이를 눈으로 보게 한다.
+type Profile = "cubic" | "quintic" | "trapezoidal";
+
+interface Sample {
+    s: number;
+    sd: number;
+    sdd: number;
+}
+
+const sampleCubic = (T: number, t: number): Sample => {
+    const u = t / T;
+    return {
+        s: 3 * u * u - 2 * u * u * u,
+        sd: 6 * t / (T * T) - 6 * t * t / (T * T * T),
+        sdd: 6 / (T * T) - 12 * t / (T * T * T),
+    };
+};
+
+const sampleQuintic = (T: number, t: number): Sample => {
+    const T3 = T ** 3, T4 = T ** 4, T5 = T ** 5;
+    return {
+        s: 10 * (t / T) ** 3 - 15 * (t / T) ** 4 + 6 * (t / T) ** 5,
+        sd: 30 * t * t / T3 - 60 * t ** 3 / T4 + 30 * t ** 4 / T5,
+        sdd: 60 * t / T3 - 180 * t * t / T4 + 120 * t ** 3 / T5,
+    };
+};
+
+interface TrapParams {
+    a: number;      // 가·감속 크기
+    ta: number;     // 가속(및 감속) 구간 길이
+    v: number;      // coast 속도
+    triangular: boolean;
+}
+
+// 삼각형(bang-bang) 프로파일: coast 가 사라진 극단. s(T)=1 을 만족하는 대칭 가·감속.
+const triangular = (T: number): TrapParams => ({a: 4 / (T * T), ta: T / 2, v: 2 / T, triangular: true});
+
+// v, T (vT>1) 로부터 a=v²/(vT−1) 를 풀어 s(T)=1 이 되게 한다. coast 가 남지 않으면 삼각형으로 강등.
+const trapParams = (T: number, v: number): TrapParams => {
+    const vT = v * T;
+    if (vT <= 1) return triangular(T);
+    const a = (v * v) / (v * T - 1);
+    const ta = v / a;
+    if (ta >= T / 2) return triangular(T);
+    return {a, ta, v, triangular: false};
+};
+
+const sampleTrap = (T: number, p: TrapParams, t: number): Sample => {
+    const {a, ta, v} = p;
+    if (t <= ta) return {s: 0.5 * a * t * t, sd: a * t, sdd: a};
+    if (t <= T - ta) return {s: v * t - v * v / (2 * a), sd: v, sdd: 0};
+    return {s: (2 * a * v * T - 2 * v * v - a * a * (t - T) * (t - T)) / (2 * a), sd: a * (T - t), sdd: -a};
+};
+
+const makeSampler = (profile: Profile, T: number, v: number): {fn: (t: number) => Sample; trap: TrapParams} => {
+    const trap = trapParams(T, v);
+    if (profile === "cubic") return {fn: (t) => sampleCubic(T, t), trap};
+    if (profile === "quintic") return {fn: (t) => sampleQuintic(T, t), trap};
+    return {fn: (t) => sampleTrap(T, trap, t), trap};
+};
+
+interface Pt {
+    t: number;
+    y: number;
+}
+
+interface Series {
+    pts: Pt[];
+    color: string;
+    width: number;
+    dash?: number[];
+}
+
+interface MiniPlotProps {
+    width: number;
+    height: number;
+    T: number;
+    series: Series[];
+    label: string;
+    colors: CanvasColors;
+    markerT: number | null;
+    markerValue: number | null;
+}
+
+// 원점이 화면 중앙인 CoordinateSystem 은 부호 있는 y-범위 그래프에 맞지 않아, 여기서는
+// 좌하단 원점의 선형 축을 직접 만든다: 데이터(t,y) → 패딩된 사각형 안의 픽셀로 매핑.
+const MiniPlot = ({width, height, T, series, label, colors, markerT, markerValue}: MiniPlotProps) => {
+    const padL = 34, padR = 10, padT = 14, padB = 16;
+    const allY = series.flatMap((s) => s.pts.map((p) => p.y));
+    let yMin = Math.min(0, ...allY);
+    let yMax = Math.max(0, ...allY);
+    if (yMax - yMin < 1e-9) yMax = yMin + 1;
+    const pad = (yMax - yMin) * 0.12;
+    yMin -= pad;
+    yMax += pad;
+
+    const toX = (t: number) => padL + (t / T) * (width - padL - padR);
+    const toY = (y: number) => padT + (1 - (y - yMin) / (yMax - yMin)) * (height - padT - padB);
+
+    const flat = (pts: Pt[]) => pts.flatMap((p) => [toX(p.t), toY(p.y)]);
+
+    return (
+        <Stage width={width} height={height} className="overflow-hidden">
+            <Layer>
+                {/* y-축과 baseline(y=0) */}
+                <Line points={[toX(0), toY(yMax), toX(0), toY(yMin)]} stroke={colors.border} strokeWidth={1}/>
+                <Line points={[toX(0), toY(0), toX(T), toY(0)]} stroke={colors.border} strokeWidth={1}/>
+                <Text x={padL + 2} y={1} text={label} fontSize={12} fontStyle="bold" fill={colors.muted}/>
+                <Text x={toX(T) - 8} y={toY(0) + 2} text="T" fontSize={11} fill={colors.muted}/>
+                <Text x={toX(0) - 6} y={toY(0) + 2} text="0" fontSize={11} fill={colors.muted}/>
+                {series.map((s, i) => (
+                    <Line key={i} points={flat(s.pts)} stroke={s.color} strokeWidth={s.width} dash={s.dash}
+                          lineCap="round" lineJoin="round"/>
+                ))}
+                {markerT !== null && (
+                    <Line points={[toX(markerT), padT, toX(markerT), height - padB]} stroke={colors.muted}
+                          strokeWidth={1} dash={[4, 4]} opacity={0.7}/>
+                )}
+                {markerT !== null && markerValue !== null && (
+                    <Circle x={toX(markerT)} y={toY(markerValue)} radius={4} fill={colors.accent}/>
+                )}
+            </Layer>
+        </Stage>
+    );
+};
+
+interface PathStripProps {
+    width: number;
+    height: number;
+    s: number;
+    colors: CanvasColors;
+}
+
+// path θ(s) 를 나타내는 수평 트랙 위에서 s(t) 값만큼 이동하는 점.
+const PathStrip = ({width, height, s, colors}: PathStripProps) => {
+    const padL = 34, padR = 10;
+    const y = height / 2 + 4;
+    const x0 = padL, x1 = width - padR;
+    const dotX = x0 + Math.max(0, Math.min(1, s)) * (x1 - x0);
+    return (
+        <Stage width={width} height={height} className="overflow-hidden">
+            <Layer>
+                <Text x={padL + 2} y={0} text="path θ(s)" fontSize={12} fontStyle="bold" fill={colors.muted}/>
+                <Line points={[x0, y, x1, y]} stroke={colors.border} strokeWidth={5} lineCap="round"/>
+                <Circle x={x0} y={y} radius={3} fill={colors.muted}/>
+                <Circle x={x1} y={y} radius={3} fill={colors.muted}/>
+                <Circle x={dotX} y={y} radius={7} fill={colors.accent} stroke={colors.surface} strokeWidth={2}/>
+            </Layer>
+        </Stage>
+    );
+};
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const REF_DASH = [5, 4];
+
+const TimeScalingScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    const [profile, setProfile] = useState<Profile>("cubic");
+    const [T, setT] = useState(2);
+    const [v, setV] = useState(0.85);
+    const [playing, setPlaying] = useState(false);
+    const [markerT, setMarkerT] = useState(0);
+    const rafRef = useRef<number>();
+    const startRef = useRef<number>(0);
+
+    useEffect(() => {
+        if (!playing) return;
+        startRef.current = performance.now();
+        const tick = (now: number) => {
+            setMarkerT(((now - startRef.current) / 1000) % T);
+            rafRef.current = requestAnimationFrame(tick);
+        };
+        rafRef.current = requestAnimationFrame(tick);
+        return () => {
+            if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        };
+    }, [playing, T]);
+
+    const {sdMax, sddMax, trap, sSeries, sdSeries, sddSeries} = useMemo(() => {
+        const N = 200;
+        const {fn, trap} = makeSampler(profile, T, v);
+        const ts = Array.from({length: N + 1}, (_, i) => (i / N) * T);
+        const active = ts.map((t) => ({t, ...fn(t)}));
+        const mk = (key: keyof Sample, color: string): Series => ({
+            pts: active.map((p) => ({t: p.t, y: p[key]})),
+            color,
+            width: 2.5,
+        });
+        const sSeries: Series[] = [mk("s", colors.accent)];
+        const sdSeries: Series[] = [mk("sd", colors.accent)];
+        const sddSeries: Series[] = [mk("sdd", colors.accent)];
+
+        // quintic 선택 시 cubic 을 흐린 점선으로 겹쳐, s̈ 그래프의 끝점 jerk 차이를 대조한다.
+        if (profile === "quintic") {
+            const ref = ts.map((t) => ({t, ...sampleCubic(T, t)}));
+            const refSeries = (key: keyof Sample): Series =>
+                ({pts: ref.map((p) => ({t: p.t, y: p[key]})), color: colors.muted, width: 1.5, dash: REF_DASH});
+            sSeries.push(refSeries("s"));
+            sdSeries.push(refSeries("sd"));
+            sddSeries.push(refSeries("sdd"));
+        }
+
+        // 이론적 peak: cubic ṡ=3/2T·, s̈=6/T² / quintic ṡ=15/8T, s̈=10/(√3 T²) / trap = v, a.
+        let sdMax: number, sddMax: number;
+        if (profile === "cubic") {
+            sdMax = 3 / (2 * T);
+            sddMax = 6 / (T * T);
+        } else if (profile === "quintic") {
+            sdMax = 15 / (8 * T);
+            sddMax = 10 / (Math.sqrt(3) * T * T);
+        } else {
+            sdMax = trap.v;
+            sddMax = trap.a;
+        }
+        return {sdMax, sddMax, trap, sSeries, sdSeries, sddSeries};
+    }, [profile, T, v, colors]);
+
+    const {fn} = useMemo(() => makeSampler(profile, T, v), [profile, T, v]);
+    const cur = fn(Math.min(markerT, T));
+    // 세로 예산(height)을 path 스트립 + 3개 그래프로 나눈다.
+    const stripH = Math.round(height * 0.14);
+    const plotH = Math.floor((height - stripH) / 3);
+
+    const btn = (p: Profile, label: string) => (
+        <button
+            type="button"
+            onClick={() => setProfile(p)}
+            className={`px-2 py-1 rounded border text-xs ${
+                profile === p
+                    ? "border-[var(--accent)] text-[var(--accent)] font-semibold"
+                    : "border-border text-muted"
+            }`}
+        >
+            {label}
+        </button>
+    );
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <div className="bg-surface border border-border rounded-lg p-1 flex flex-col gap-1" style={{width}}>
+                <PathStrip width={width - 8} height={stripH} s={cur.s} colors={colors}/>
+                <MiniPlot width={width - 8} height={plotH} T={T} series={sSeries} label="s(t)"
+                          colors={colors} markerT={playing ? markerT : null} markerValue={cur.s}/>
+                <MiniPlot width={width - 8} height={plotH} T={T} series={sdSeries} label="ṡ(t)"
+                          colors={colors} markerT={playing ? markerT : null} markerValue={cur.sd}/>
+                <MiniPlot width={width - 8} height={plotH} T={T} series={sddSeries} label="s̈(t)"
+                          colors={colors} markerT={playing ? markerT : null} markerValue={cur.sdd}/>
+            </div>
+
+            <div className="w-full flex flex-wrap items-center gap-2 justify-center">
+                {btn("cubic", "cubic")}
+                {btn("quintic", "quintic")}
+                {btn("trapezoidal", "trapezoidal")}
+                <button
+                    type="button"
+                    onClick={() => setPlaying((p) => !p)}
+                    className="px-2 py-1 rounded border border-[var(--accent)] text-[var(--accent)] text-xs font-semibold"
+                >
+                    {playing ? "❚❚ Pause" : "▶ Play"}
+                </button>
+            </div>
+
+            <div className="w-full flex flex-col gap-1 text-xs text-muted">
+                <label className="flex items-center gap-2">
+                    <span className="w-8 shrink-0">T</span>
+                    <input type="range" min={0.5} max={4} step={0.1} value={T}
+                           onChange={(e) => setT(parseFloat(e.target.value))}
+                           className="w-full accent-[var(--accent)]" aria-label="total time T"/>
+                    <span className="w-12 shrink-0 text-right tabular-nums">{T.toFixed(1)} s</span>
+                </label>
+                {profile === "trapezoidal" && (
+                    <label className="flex items-center gap-2">
+                        <span className="w-8 shrink-0">v</span>
+                        <input type="range" min={0.5} max={3} step={0.05} value={v}
+                               onChange={(e) => setV(parseFloat(e.target.value))}
+                               className="w-full accent-[var(--accent)]" aria-label="coast speed v"/>
+                        <span className="w-12 shrink-0 text-right tabular-nums">{v.toFixed(2)}</span>
+                    </label>
+                )}
+            </div>
+
+            <div className="w-full text-xs text-muted text-center">
+                peak ṡ = {sdMax.toFixed(2)}/s · peak s̈ = {sddMax.toFixed(2)}/s²
+                {profile === "trapezoidal" && (
+                    trap.triangular
+                        ? <span className="text-[var(--accent)] font-semibold"> · coast vanished → bang-bang</span>
+                        : <span> · a = {trap.a.toFixed(2)}, tₐ = {trap.ta.toFixed(2)} s</span>
+                )}
+                {profile === "cubic" && <span> · s̈ jumps at t=0,T → infinite jerk</span>}
+                {profile === "quintic" && <span> · s̈(0)=s̈(T)=0 → no jerk spike</span>}
+            </div>
+        </div>
+    );
+};
+
+const TimeScalingProfiles = () => {
+    return <CanvasFigure
+        label="time scaling · s(t), ṡ(t), s̈(t) for cubic / quintic / trapezoidal"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<TimeScalingScene width={460} height={460}/>}
+    >
+        <TimeScalingScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default TimeScalingProfiles;

--- a/document/src/components/pages/chapter9/ViaPointTrajectory.tsx
+++ b/document/src/components/pages/chapter9/ViaPointTrajectory.tsx
@@ -1,0 +1,177 @@
+import {useEffect, useMemo, useRef, useState} from "react";
+import {Arrow, Circle, Line, Text} from "react-konva";
+import CoordinateSystem from "../../2d/CoordinateCanvas";
+import CanvasFigure from "../../CanvasFigure";
+import {globalToMap} from "../../../libs/konvaUtils";
+import {useCanvasColors} from "../../../libs/useTheme";
+
+// via point 궤적: 정해진 시각에 네 점을 지나는 곡선을 x(t)·y(t) 각각 piecewise cubic 으로 보간한다.
+// 내부 via 점의 속도 벡터(슬라이더)를 바꾸면 곡선이 휘어, "via 속도가 경로 모양을 결정한다"를 보게 한다.
+const XS = [0, 0, 1, 1] as const;      // 네 via 점의 x 좌표
+const YS = [0, 1, 1, 0] as const;      // 네 via 점의 y 좌표
+const DT = 1;                          // 각 구간 지속 시간 (시각 T=0,1,2,3)
+const TOTAL = DT * (XS.length - 1);    // 궤적 전체 시간
+const RESOLUTION = 0.013;
+const CX = 0.5, CY = 0.5;              // via 점 bounding box 중심을 원점에 맞춘다
+const ARROW_COLOR = "#f2a63a";
+const DOT_COLOR = "#e0533d";
+
+// 한 구간의 3차 계수. Δt∈[0,ΔT] 에서 β=a0+a1Δt+a2Δt²+a3Δt³, (βj,β̇j)→(β_{j+1},β̇_{j+1}) 를 잇는다.
+const cubicCoeffs = (b0: number, b1: number, bd0: number, bd1: number, dT: number) => {
+    const a0 = b0;
+    const a1 = bd0;
+    const a2 = (3 * b1 - 3 * b0 - 2 * bd0 * dT - bd1 * dT) / (dT * dT);
+    const a3 = (2 * b0 + (bd0 + bd1) * dT - 2 * b1) / (dT * dT * dT);
+    return [a0, a1, a2, a3] as const;
+};
+
+type Coeffs = readonly [number, number, number, number];
+
+const evalCubic = (c: Coeffs, dt: number) =>
+    c[0] + c[1] * dt + c[2] * dt * dt + c[3] * dt * dt * dt;
+
+interface SceneProps {
+    width: number;
+    height: number;
+}
+
+const ViaScene = ({width, height}: SceneProps) => {
+    const colors = useCanvasColors();
+    // 내부 via P2, P3 의 속도 벡터. 양 끝점 속도는 0 으로 고정.
+    const [vel, setVel] = useState({vx2: 1, vy2: 0, vx3: 0, vy3: -1});
+    const [playing, setPlaying] = useState(false);
+    const [tNow, setTNow] = useState(0);
+    const rafRef = useRef<number>();
+    const startRef = useRef<number>(0);
+
+    const {xc, yc} = useMemo(() => {
+        const vx = [0, vel.vx2, vel.vx3, 0];
+        const vy = [0, vel.vy2, vel.vy3, 0];
+        const xc: Coeffs[] = [], yc: Coeffs[] = [];
+        for (let j = 0; j < XS.length - 1; j++) {
+            xc.push(cubicCoeffs(XS[j], XS[j + 1], vx[j], vx[j + 1], DT));
+            yc.push(cubicCoeffs(YS[j], YS[j + 1], vy[j], vy[j + 1], DT));
+        }
+        return {xc, yc};
+    }, [vel]);
+
+    // 전체 시각 t → (x,y). 구간을 찾아 국소 시간으로 3차식을 평가한다.
+    const at = (t: number) => {
+        const tc = Math.max(0, Math.min(TOTAL, t));
+        const j = Math.min(XS.length - 2, Math.floor(tc / DT));
+        const dt = tc - j * DT;
+        return {x: evalCubic(xc[j], dt), y: evalCubic(yc[j], dt)};
+    };
+
+    useEffect(() => {
+        if (!playing) return;
+        startRef.current = performance.now();
+        const tick = (now: number) => {
+            setTNow(((now - startRef.current) / 1000) % TOTAL);
+            rafRef.current = requestAnimationFrame(tick);
+        };
+        rafRef.current = requestAnimationFrame(tick);
+        return () => {
+            if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        };
+    }, [playing]);
+
+    const toPx = (x: number, y: number) => globalToMap(width, height, x - CX, y - CY, RESOLUTION);
+
+    // 곡선을 촘촘히 샘플해 폴리라인으로.
+    const path = useMemo(() => {
+        const N = 120;
+        const flat: number[] = [];
+        for (let i = 0; i <= N; i++) {
+            const {x, y} = at((i / N) * TOTAL);
+            const m = toPx(x, y);
+            flat.push(m.x, m.y);
+        }
+        return flat;
+    }, [xc, yc]);
+
+    const vias = XS.map((x, i) => toPx(x, YS[i]));
+    const dot = at(tNow);
+    const dotPx = toPx(dot.x, dot.y);
+
+    // 내부 via 점의 속도 접선 화살표 (데이터 단위 벡터를 0.35배로 축소해 그린다).
+    const tangent = (i: number, vx: number, vy: number) => {
+        const base = toPx(XS[i], YS[i]);
+        const end = toPx(XS[i] + 0.35 * vx, YS[i] + 0.35 * vy);
+        return [base.x, base.y, end.x, end.y];
+    };
+
+    const setV = (k: keyof typeof vel, val: number) => setVel((p) => ({...p, [k]: val}));
+
+    const sliders: Array<[keyof typeof vel, string]> = [
+        ["vx2", "P₂ vx"], ["vy2", "P₂ vy"], ["vx3", "P₃ vx"], ["vy3", "P₃ vy"],
+    ];
+
+    return (
+        <div className="flex flex-col gap-2 items-center" style={{width}}>
+            <CoordinateSystem
+                width={width}
+                height={height}
+                resolution={RESOLUTION}
+                className="bg-surface border border-border rounded-lg"
+            >
+                <Line points={path} stroke={colors.accent} strokeWidth={3} lineCap="round" lineJoin="round"/>
+                <Arrow points={tangent(1, vel.vx2, vel.vy2)} stroke={ARROW_COLOR} fill={ARROW_COLOR}
+                       strokeWidth={2.5} pointerLength={8} pointerWidth={8}/>
+                <Arrow points={tangent(2, vel.vx3, vel.vy3)} stroke={ARROW_COLOR} fill={ARROW_COLOR}
+                       strokeWidth={2.5} pointerLength={8} pointerWidth={8}/>
+                {vias.map((p, i) => (
+                    <Circle key={i} x={p.x} y={p.y} radius={6} fill={colors.surface} stroke={colors.text}
+                            strokeWidth={2}/>
+                ))}
+                {vias.map((p, i) => (
+                    <Text key={`l-${i}`} x={p.x + 9} y={p.y - 6} text={`P${i + 1}`} fontSize={12}
+                          fontStyle="bold" fill={colors.muted}/>
+                ))}
+                {playing && (
+                    <Circle x={dotPx.x} y={dotPx.y} radius={6} fill={DOT_COLOR} stroke={colors.surface}
+                            strokeWidth={2}/>
+                )}
+            </CoordinateSystem>
+
+            <div className="w-full flex items-center justify-center">
+                <button
+                    type="button"
+                    onClick={() => setPlaying((p) => !p)}
+                    className="px-2 py-1 rounded border border-[var(--accent)] text-[var(--accent)] text-xs font-semibold"
+                >
+                    {playing ? "❚❚ Pause" : "▶ Play"}
+                </button>
+            </div>
+
+            <div className="w-full grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted">
+                {sliders.map(([k, label]) => (
+                    <label key={k} className="flex items-center gap-1">
+                        <span className="w-12 shrink-0">{label}</span>
+                        <input type="range" min={-3} max={3} step={0.1} value={vel[k]}
+                               onChange={(e) => setV(k, parseFloat(e.target.value))}
+                               className="w-full accent-[var(--accent)]" aria-label={label}/>
+                        <span className="w-8 shrink-0 text-right tabular-nums">{vel[k].toFixed(1)}</span>
+                    </label>
+                ))}
+            </div>
+            <div className="w-full text-xs text-muted text-center">
+                piecewise-cubic interpolation · continuous position &amp; velocity at every via point
+            </div>
+        </div>
+    );
+};
+
+const ViaPointTrajectory = () => {
+    return <CanvasFigure
+        label="via-point trajectory · tune the interior via velocities to bend the path"
+        tight
+        bodyClassName="w-fit"
+        className="w-full"
+        modal={<ViaScene width={460} height={460}/>}
+    >
+        <ViaScene width={320} height={320}/>
+    </CanvasFigure>;
+};
+
+export default ViaPointTrajectory;

--- a/document/src/pages/chapters/Chapter7.tsx
+++ b/document/src/pages/chapters/Chapter7.tsx
@@ -1,0 +1,148 @@
+import {BlockMath, InlineMath} from "../../components/math/Tex";
+import FourBarLinkage from "../../components/pages/chapter7/FourBarLinkage";
+import RPRParallel from "../../components/pages/chapter7/RPRParallel";
+
+const Chapter7 = () => {
+    return (
+        <>
+            <h2>Closed Chains and Parallel Mechanisms</h2>
+            <p>
+                Every mechanism so far has been an <strong>open chain</strong>: a single serial string of links
+                running from base to end-effector. A <strong>closed chain</strong> instead contains one or more{" "}
+                <strong>loops</strong>, so a link can be reached by more than one path. The most important closed
+                chains are <strong>parallel mechanisms</strong> — a <strong>fixed platform</strong> and a{" "}
+                <strong>moving platform</strong> joined by several <strong>legs</strong>, each usually a short open
+                chain. Only some of the joints are <strong>actuated</strong>; the rest are passive and simply go
+                along for the ride. Because the legs share the moving platform, the joint variables are not free:
+                they must satisfy <strong>loop-closure constraints</strong> that keep every leg attached to the same
+                rigid platform.
+            </p>
+            <p>
+                This creates a striking <strong>duality</strong> with serial arms. For an open chain forward
+                kinematics is a direct evaluation while inverse kinematics is the hard, multi-solution problem. For a
+                parallel mechanism the roles flip: <strong>inverse kinematics is usually easy — the actuator values
+                follow directly from the platform pose — while forward kinematics is hard.</strong> A chosen set of
+                actuator values may be geometrically infeasible (the legs simply cannot close the loop), or it may
+                correspond to several distinct platform poses at once.
+            </p>
+            <p>
+                Mobility is counted the same way as before, with <strong>Grübler's formula</strong>. For a mechanism
+                of <InlineMath math='N'/> links (including ground) connected by <InlineMath math='J'/> joints in a{" "}
+                <InlineMath math='m'/>-dof space (<InlineMath math='m=3'/> planar, <InlineMath math='m=6'/> spatial),
+            </p>
+            <BlockMath math={`\\mathrm{dof} = m(N - 1 - J) + \\sum_{i=1}^{J} f_i`}/>
+            <p>
+                where <InlineMath math='f_i'/> is the number of freedoms at joint <InlineMath math='i'/>. The{" "}
+                <strong>four-bar linkage</strong> below is the simplest closed chain: four links (one is ground) and
+                four revolute joints form a single loop. Grübler gives{" "}
+                <InlineMath math='3(4 - 1 - 4) + 4 = 1'/>, so its entire configuration space is{" "}
+                <strong>one-dimensional</strong> — turning the input crank determines everything else through
+                loop closure. Sweep the driving angle and watch the coupler and rocker follow.
+            </p>
+            <FourBarLinkage/>
+
+            <h2>Forward and Inverse Kinematics</h2>
+            <p>
+                Take the planar <strong>3&times;RPR</strong> mechanism as a case study: a moving platform is held by
+                three legs, each an <strong>R</strong>evolute base joint, an actuated <strong>P</strong>rismatic
+                leg, and an <strong>R</strong>evolute platform joint. It has three degrees of freedom, matching the
+                planar pose <InlineMath math='(p_x, p_y, \phi)'/> of the platform; the three prismatic legs are
+                actuated and every revolute joint is passive. Let the fixed base points be{" "}
+                <InlineMath math='a_i'/> (in the fixed frame <InlineMath math='\{s\}'/>) and the platform attachment
+                points be <InlineMath math='b_i'/> (in the body frame <InlineMath math='\{b\}'/>).
+            </p>
+            <p>
+                Given the pose, each platform point in the fixed frame is{" "}
+                <InlineMath math='B_i = p + R(\phi)\,b_i'/>, so the leg length is simply the distance from{" "}
+                <InlineMath math='a_i'/> to <InlineMath math='B_i'/>:
+            </p>
+            <BlockMath math={`s_i^2 = \\big(p_x + b_{ix}\\cos\\phi - b_{iy}\\sin\\phi - a_{ix}\\big)^2 + \\big(p_y + b_{ix}\\sin\\phi + b_{iy}\\cos\\phi - a_{iy}\\big)^2`}/>
+            <p>
+                <strong>Inverse kinematics is therefore a direct evaluation</strong> — plug in the pose and read off
+                the three leg lengths, with no iteration and no branching. Drag the pose sliders below and watch{" "}
+                <InlineMath math='s_1, s_2, s_3'/> update instantly; this trivial forward-to-actuator map is the
+                whole point of the figure.
+            </p>
+            <RPRParallel/>
+            <p>
+                The <strong>forward</strong> problem is the hard direction. Given the three lengths{" "}
+                <InlineMath math='s_1, s_2, s_3'/>, finding the pose <InlineMath math='(p_x, p_y, \phi)'/> means
+                solving the three constraint equations simultaneously. Applying the{" "}
+                <strong>tangent half-angle substitution</strong> <InlineMath math='t = \tan(\phi/2)'/> eliminates
+                the trigonometric terms and reduces the system to a single{" "}
+                <strong>sixth-order polynomial</strong> — so a given set of leg lengths can correspond to{" "}
+                <strong>up to six distinct platform poses</strong>.
+            </p>
+            <p>
+                The spatial analogue is the <strong>6&times;SPS Stewart–Gough platform</strong>, six actuated legs
+                each a <strong>S</strong>pherical–<strong>P</strong>rismatic–<strong>S</strong>pherical chain
+                between a fixed and a moving platform. Its inverse kinematics is just as trivial —{" "}
+                <InlineMath math='s_i = \lVert p + R b_i - a_i \rVert'/> — but its forward kinematics is far worse
+                than the planar case: it admits <strong>up to 40 solutions</strong>. This is exactly the serial/
+                parallel duality in its most extreme form.
+            </p>
+
+            <h2>Differential Kinematics</h2>
+            <p>
+                Velocity kinematics for a closed chain must respect the loops. Only the <strong>actuated</strong>{" "}
+                joints receive commanded velocities; the <strong>passive</strong> joint velocities are then
+                determined by the constraints. Partition the joint vector into actuated{" "}
+                <InlineMath math='q_a'/> and passive <InlineMath math='q_p'/>. Differentiating the loop-closure
+                constraints with respect to time gives a linear relation between the two,
+            </p>
+            <BlockMath math={`H_a(q)\\,\\dot q_a + H_p(q)\\,\\dot q_p = 0 \\quad\\Longrightarrow\\quad \\dot q_p = -H_p^{-1}(q)\\,H_a(q)\\,\\dot q_a`}/>
+            <p>
+                valid wherever <InlineMath math='H_p'/> is invertible. Once the passive velocities are recovered,
+                the end-effector twist is obtained from any single leg as{" "}
+                <InlineMath math='\mathcal{V} = J(q_a, q_p)\,\dot q_a'/>. The <strong>constraint Jacobian</strong> is
+                the piece that has no counterpart in an open chain: it is what couples the legs together, and its
+                rank governs how the commanded actuator velocities propagate to the platform.
+            </p>
+            <p>
+                Statics gives an especially clean route for the Stewart–Gough platform. Because each leg is a
+                prismatic strut, the force it exerts on the platform acts <strong>along the leg</strong>, a pure
+                wrench whose screw axis is the leg's line. Collecting these six lines and applying the same
+                velocity–force duality used for open chains, <InlineMath math='\tau = J^{\mathsf T}\mathcal{F}'/>,
+                yields the <strong>inverse Jacobian</strong> directly from the leg geometry — no differentiation of a
+                forward-kinematics map is required.
+            </p>
+
+            <h2>Singularities</h2>
+            <p>
+                Closed chains are richer than open ones near singularities, and it helps to separate three distinct
+                kinds.
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+                <li>
+                    <strong>Configuration-space singularities</strong> — points where the constraint-surface itself
+                    is not a smooth manifold: self-intersections and bifurcations where the constraint Jacobian{" "}
+                    <InlineMath math='\partial f/\partial\theta'/> loses rank. They are a property of the geometry
+                    alone and are <strong>independent of which joints are actuated</strong>.
+                </li>
+                <li>
+                    <strong>Actuator singularities</strong> — configurations where <InlineMath math='H_p'/> drops
+                    rank (<InlineMath math='\operatorname{rank} H_p < p'/>), so the actuated joints can no longer be
+                    controlled independently. A <em>nondegenerate</em> actuator singularity rigidifies the
+                    mechanism when the actuators are locked; a <em>degenerate</em> one lets the inner links move
+                    even with the actuators locked. These depend on the <strong>choice of actuated joints</strong>{" "}
+                    and can often be removed by relocating an actuator.
+                </li>
+                <li>
+                    <strong>End-effector singularities</strong> — the moving platform loses the ability to move
+                    instantaneously in some direction, exactly as for an open chain. These depend on the
+                    <strong> placement of the end-effector frame</strong>, not on the actuator choice.
+                </li>
+            </ul>
+            <p>
+                The four-bar figure above makes the first kind visible. In its C-space panel the two curves are the
+                two <strong>assembly branches</strong>, and the marked points where they meet are{" "}
+                <strong>configuration-space singularities</strong> — bifurcation points where the coupler and rocker
+                become collinear, the two circle intersections merge, and the mechanism can switch from one branch to
+                the other. Because the meeting is a feature of the loop-closure surface itself, it stays put no
+                matter which joint we choose to drive.
+            </p>
+        </>
+    )
+}
+
+export default Chapter7

--- a/document/src/pages/chapters/Chapter8.tsx
+++ b/document/src/pages/chapters/Chapter8.tsx
@@ -1,0 +1,178 @@
+import {BlockMath, InlineMath} from "../../components/math/Tex";
+import TwoRDynamics from "../../components/pages/chapter8/TwoRDynamics";
+import MassMatrixEllipse from "../../components/pages/chapter8/MassMatrixEllipse";
+
+const Chapter8 = () => {
+    return (
+        <>
+            <h2>The Equations of Motion</h2>
+            <p>
+                Kinematics answers <em>where</em> a robot can go; <strong>dynamics</strong> answers what forces and
+                torques make it go there. For an open chain the relationship between joint torques and joint motion
+                is captured by the <strong>equations of motion</strong>,
+            </p>
+            <BlockMath math={`\\tau = M(\\theta)\\,\\ddot\\theta + h(\\theta, \\dot\\theta)`}/>
+            <p>
+                Here <InlineMath math='M(\theta)'/> is the <InlineMath math='n \times n'/>{" "}
+                <strong>mass matrix</strong> — symmetric and positive-definite, and configuration-dependent because a
+                folded arm carries its inertia differently than an extended one. The term{" "}
+                <InlineMath math='h(\theta, \dot\theta)'/> lumps together everything that is not proportional to
+                acceleration: <strong>centripetal</strong> and <strong>Coriolis</strong> forces (quadratic in{" "}
+                <InlineMath math='\dot\theta'/>), <strong>gravity</strong>, and friction. Two dual problems fall out
+                of this one equation:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+                <li>
+                    <strong>Inverse dynamics</strong>: given a desired motion{" "}
+                    <InlineMath math='(\theta, \dot\theta, \ddot\theta)'/>, compute the torques{" "}
+                    <InlineMath math='\tau'/> that produce it. This is what a controller evaluates to command the
+                    motors.
+                </li>
+                <li>
+                    <strong>Forward dynamics</strong>: given the applied torques{" "}
+                    <InlineMath math='(\theta, \dot\theta, \tau)'/>, solve for the resulting acceleration{" "}
+                    <InlineMath math='\ddot\theta = M^{-1}(\theta)\big(\tau - h(\theta, \dot\theta)\big)'/>. This is
+                    the basis of <strong>simulation</strong>.
+                </li>
+            </ul>
+            <p>
+                There are two standard routes to these equations. The <strong>Lagrangian</strong> formulation is
+                energy-based and elegant for chains with few degrees of freedom: form the Lagrangian{" "}
+                <InlineMath math='\mathcal{L} = \mathcal{K} - \mathcal{P}'/> from kinetic and potential energy, and
+                the torques follow from
+            </p>
+            <BlockMath math={`\\tau = \\frac{d}{dt}\\frac{\\partial \\mathcal{L}}{\\partial \\dot\\theta} - \\frac{\\partial \\mathcal{L}}{\\partial \\theta}`}/>
+            <p>
+                The <strong>Newton–Euler</strong> formulation is recursive and stays efficient for general chains of
+                any length. We work the Lagrangian route by hand on a 2R arm next, then meet its recursive
+                counterpart.
+            </p>
+
+            <h2>Lagrangian Dynamics of a 2R Arm</h2>
+            <p>
+                Take the planar 2R arm with point masses <InlineMath math='m_1, m_2'/> at the ends of links of
+                length <InlineMath math='L_1, L_2'/>, gravity acting in <InlineMath math='-\hat y'/>. The kinetic
+                energy is the sum of <InlineMath math='\tfrac12 m v^2'/> over the two masses, and the potential
+                energy is <InlineMath math='m g y'/> summed over their heights,
+            </p>
+            <BlockMath math={`\\mathcal{K} = \\tfrac12 m_1 L_1^2 \\dot\\theta_1^2 + \\tfrac12 m_2\\big(L_1^2\\dot\\theta_1^2 + L_2^2(\\dot\\theta_1+\\dot\\theta_2)^2 + 2 L_1 L_2 \\cos\\theta_2\\, \\dot\\theta_1(\\dot\\theta_1+\\dot\\theta_2)\\big)`}/>
+            <p>
+                Grinding <InlineMath math='\tau = \tfrac{d}{dt}\partial_{\dot\theta}\mathcal{L} - \partial_\theta\mathcal{L}'/>{" "}
+                through this energy gives the three ingredients of{" "}
+                <InlineMath math='\tau = M(\theta)\ddot\theta + c(\theta,\dot\theta) + g(\theta)'/>. The mass matrix
+                is
+            </p>
+            <BlockMath math={`M(\\theta) = \\begin{bmatrix} m_1 L_1^2 + m_2\\big(L_1^2 + 2 L_1 L_2 \\cos\\theta_2 + L_2^2\\big) & m_2\\big(L_1 L_2 \\cos\\theta_2 + L_2^2\\big) \\\\[4pt] m_2\\big(L_1 L_2 \\cos\\theta_2 + L_2^2\\big) & m_2 L_2^2 \\end{bmatrix}`}/>
+            <p>
+                the Coriolis / centripetal vector is
+            </p>
+            <BlockMath math={`c(\\theta, \\dot\\theta) = \\begin{bmatrix} -m_2 L_1 L_2 \\sin\\theta_2\\,\\big(2\\dot\\theta_1\\dot\\theta_2 + \\dot\\theta_2^2\\big) \\\\[4pt] m_2 L_1 L_2\\,\\dot\\theta_1^2 \\sin\\theta_2 \\end{bmatrix}`}/>
+            <p>
+                and the gravity vector is
+            </p>
+            <BlockMath math={`g(\\theta) = \\begin{bmatrix} (m_1 + m_2) L_1 g \\cos\\theta_1 + m_2 g L_2 \\cos(\\theta_1 + \\theta_2) \\\\[4pt] m_2 g L_2 \\cos(\\theta_1 + \\theta_2) \\end{bmatrix}`}/>
+            <p>
+                Look at the <em>structure</em> rather than the algebra. The equations are <strong>linear in{" "}
+                <InlineMath math='\ddot\theta'/></strong>, <strong>quadratic in{" "}
+                <InlineMath math='\dot\theta'/></strong> — the <InlineMath math='\dot\theta_i^2'/> terms are
+                centripetal, the <InlineMath math='\dot\theta_i\dot\theta_j'/> cross terms are Coriolis — and{" "}
+                <strong>trigonometric in <InlineMath math='\theta'/></strong>. Crucially, the off-diagonal entry{" "}
+                <InlineMath math='M_{12} = m_2(L_1 L_2 \cos\theta_2 + L_2^2)'/> is generally nonzero: the joints are{" "}
+                <strong>inertially coupled</strong>, so an acceleration commanded at joint 1 exerts a reaction
+                torque at joint 2, and vice versa. The coupling vanishes only when{" "}
+                <InlineMath math='\cos\theta_2 = -L_2/L_1'/>.
+            </p>
+            <p>
+                The figure below integrates exactly these equations in real time. With torques at zero and gravity
+                on, the arm is a <strong>double pendulum</strong>: give it an off-vertical start and it swings.
+                Nudge the joint torques, toggle gravity, or switch on gravity compensation and watch how the same
+                model responds.
+            </p>
+            <TwoRDynamics/>
+
+            <h2>Newton–Euler Inverse Dynamics</h2>
+            <p>
+                Forming <InlineMath math='M(\theta)'/> and <InlineMath math='h(\theta,\dot\theta)'/> symbolically, as
+                above, becomes hopeless for a six- or seven-joint arm. The <strong>Newton–Euler</strong> algorithm
+                sidesteps the symbols with two recursive sweeps along the chain and computes the inverse dynamics in
+                time <InlineMath math='O(n)'/> in the number of joints.
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+                <li>
+                    <strong>Forward pass (base → tip)</strong>: starting from the known base motion, propagate each
+                    link's configuration outward, together with its twist{" "}
+                    <InlineMath math='\mathcal{V}_i'/> and twist acceleration{" "}
+                    <InlineMath math='\dot{\mathcal{V}}_i'/>. Each link inherits the motion of its parent and adds
+                    the contribution of its own joint velocity and acceleration.
+                </li>
+                <li>
+                    <strong>Backward pass (tip → base)</strong>: starting from any force the tip exerts on the
+                    environment, propagate the wrench <InlineMath math='\mathcal{F}_i'/> that each link applies to
+                    its parent inward. The joint torque is the component of that wrench along the joint's screw axis,
+                    <InlineMath math='\ \tau_i = \mathcal{F}_i^{\mathsf T}\mathcal{A}_i'/>.
+                </li>
+            </ul>
+            <p>
+                Each link's mass distribution enters through its <InlineMath math='6\times 6'/>{" "}
+                <strong>spatial inertia matrix</strong> <InlineMath math='\mathcal{G}_i = \operatorname{diag}(\mathcal{I}_i,\, m_i I)'/>,
+                which packages the rotational inertia <InlineMath math='\mathcal{I}_i'/> and the point-mass block{" "}
+                <InlineMath math='m_i I'/> together so that a spatial force relates to a spatial acceleration by{" "}
+                <InlineMath math='\mathcal{F} = \mathcal{G}\dot{\mathcal{V}} - [\mathrm{ad}_{\mathcal{V}}]^{\mathsf T}\mathcal{G}\mathcal{V}'/>.
+                No explicit <InlineMath math='M(\theta)'/> is ever assembled. Yet the same routine is the workhorse
+                for building it when needed: running inverse dynamics with{" "}
+                <InlineMath math='\dot\theta = 0'/>, <InlineMath math='g = 0'/> and{" "}
+                <InlineMath math='\ddot\theta = e_j'/> returns the <InlineMath math='j'/>-th column of{" "}
+                <InlineMath math='M(\theta)'/>, so <InlineMath math='n'/> passes recover the whole mass matrix, and
+                one more pass with <InlineMath math='\ddot\theta = 0'/> recovers{" "}
+                <InlineMath math='h(\theta,\dot\theta)'/> in closed form.
+            </p>
+
+            <h2>Forward Dynamics and Simulation</h2>
+            <p>
+                To <strong>simulate</strong> a robot we run the equations the other way. At each instant solve the
+                forward-dynamics problem for the acceleration,
+            </p>
+            <BlockMath math={`\\ddot\\theta = M^{-1}(\\theta)\\big(\\tau - c(\\theta,\\dot\\theta) - g(\\theta)\\big)`}/>
+            <p>
+                then integrate <InlineMath math='(\theta, \dot\theta)'/> forward one time step and repeat, with an
+                explicit Euler, semi-implicit Euler, or Runge–Kutta integrator. This loop is exactly what drives the
+                live simulation above. With <InlineMath math='\tau = 0'/> and gravity on, that 2R arm is a{" "}
+                <strong>double pendulum</strong>: energy-conserving in principle, yet <strong>chaotic</strong> — two
+                nearly identical starts diverge to completely different trajectories within a few swings.
+            </p>
+            <p>
+                Setting <InlineMath math='\tau = g(\theta)'/> at every step is <strong>gravity compensation</strong>:
+                the applied torque exactly cancels the gravity term, so the arm floats as if weightless and drifts
+                only under the torques you add on top. Two caveats about the numerics:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+                <li>
+                    <strong>Energy drift</strong>: plain Euler integration slowly injects or bleeds energy, so an
+                    ideal double pendulum will visibly gain or lose swing. Smaller steps, or symplectic / RK4
+                    integrators, keep the energy honest — watch the reported <InlineMath math='E'/> in the figure to
+                    see how well it holds.
+                </li>
+                <li>
+                    <strong>Frame-rate independence</strong>: physics is integrated on a fixed small sub-step,
+                    decoupled from the display frame rate, so the motion looks the same whether the browser renders
+                    at 30 or 120 fps.
+                </li>
+            </ul>
+            <p>
+                Finally, the operator that turns torque into acceleration is <InlineMath math='M^{-1}(\theta)'/>
+                itself, and it is strongly configuration-dependent. Map the unit circle of joint torques{" "}
+                <InlineMath math='\{u : \lVert u\rVert = 1\}'/> through <InlineMath math='M^{-1}'/> and it becomes an{" "}
+                <strong>acceleration ellipse</strong> <InlineMath math='\{M^{-1}u\}'/> in the{" "}
+                <InlineMath math='(\ddot\theta_1, \ddot\theta_2)'/> plane. A round ellipse means the arm accelerates
+                about equally easily in every direction; a stretched one means it is easy to accelerate one way and
+                sluggish and coupled the other. Sweep <InlineMath math='\theta_2'/> below: as the arm folds
+                (<InlineMath math='\theta_2 \to \pm\pi'/>) the ellipse rounds out, and as it straightens
+                (<InlineMath math='\theta_2 \to 0'/>) the growing off-diagonal of <InlineMath math='M'/> stretches
+                and tilts it.
+            </p>
+            <MassMatrixEllipse/>
+        </>
+    )
+}
+
+export default Chapter8

--- a/document/src/pages/chapters/Chapter9.tsx
+++ b/document/src/pages/chapters/Chapter9.tsx
@@ -1,0 +1,120 @@
+import {BlockMath, InlineMath} from "../../components/math/Tex";
+import TimeScalingProfiles from "../../components/pages/chapter9/TimeScalingProfiles";
+import ViaPointTrajectory from "../../components/pages/chapter9/ViaPointTrajectory";
+
+const Chapter9 = () => {
+    return (
+        <>
+            <h2>Paths and Time Scaling</h2>
+            <p>
+                A <strong>trajectory</strong> specifies not just the shape a robot traces but{" "}
+                <em>when</em> it reaches each configuration. It is cleanest to split those two questions.
+                A <strong>path</strong> <InlineMath math='\theta(s)'/> is a purely geometric curve through the
+                joint space, parameterized by a scalar <InlineMath math='s \in [0, 1]'/> that runs from the start{" "}
+                <InlineMath math='(s=0)'/> to the goal <InlineMath math='(s=1)'/>. A <strong>time scaling</strong>{" "}
+                <InlineMath math='s(t)'/>, <InlineMath math='t \in [0, T]'/>, then says how fast the parameter is
+                swept, turning the static path into a motion <InlineMath math='\theta(s(t))'/>.
+            </p>
+            <p>
+                Differentiating by the chain rule ties the two together. The joint velocities and accelerations are
+            </p>
+            <BlockMath math={`\\dot\\theta = \\frac{d\\theta}{ds}\\,\\dot s, \\qquad \\ddot\\theta = \\frac{d\\theta}{ds}\\,\\ddot s + \\frac{d^2\\theta}{ds^2}\\,\\dot s^{\\,2}`}/>
+            <p>
+                so both the path <InlineMath math='\theta(s)'/> and the time scaling <InlineMath math='s(t)'/> must be
+                twice differentiable for the motion to have a well-defined acceleration. The simplest path is the{" "}
+                <strong>straight line in joint space</strong>,
+            </p>
+            <BlockMath math={`\\theta(s) = \\theta_\\text{start} + s\\,(\\theta_\\text{end} - \\theta_\\text{start})`}/>
+            <p>
+                which is convex and therefore automatically respects box-shaped joint limits: every intermediate
+                configuration is a weighted average of two legal ones. A straight line in <em>task</em> space is
+                often more natural to specify, but it can leave the reachable workspace or pass near a{" "}
+                <strong>singularity</strong>, where the required joint velocities blow up. Whichever path is chosen,
+                the remaining freedom is the time scaling below.
+            </p>
+            <TimeScalingProfiles/>
+
+            <h2>Polynomial Time Scaling</h2>
+            <p>
+                A point-to-point motion must start and end at rest, so <InlineMath math='s(0)=0'/>,{" "}
+                <InlineMath math='s(T)=1'/>, and <InlineMath math='\dot s(0)=\dot s(T)=0'/>. Four conditions fix a{" "}
+                <strong>cubic</strong> (third-order) time scaling <InlineMath math='s(t) = a_0 + a_1 t + a_2 t^2 + a_3 t^3'/>,
+                which works out to
+            </p>
+            <BlockMath math={`s(t) = 3\\Big(\\tfrac{t}{T}\\Big)^2 - 2\\Big(\\tfrac{t}{T}\\Big)^3, \\qquad \\dot s(t) = \\frac{6t}{T^2} - \\frac{6t^2}{T^3}, \\qquad \\ddot s(t) = \\frac{6}{T^2} - \\frac{12t}{T^3}`}/>
+            <p>
+                The speed peaks at the midpoint with <InlineMath math='\dot s_\text{max} = \tfrac{3}{2T}'/>, so the
+                motion is fast in the middle and slow at the ends. But the acceleration <InlineMath math='\ddot s'/>{" "}
+                is <strong>nonzero at the endpoints</strong> and jumps discontinuously from zero to{" "}
+                <InlineMath math='6/T^2'/> at <InlineMath math='t=0'/> (and back at <InlineMath math='t=T'/>). That
+                step in acceleration is an <strong>infinite jerk</strong> (jerk is <InlineMath math='da/dt'/>), which
+                excites structural vibration in the arm.
+            </p>
+            <p>
+                Adding <InlineMath math='\ddot s(0) = \ddot s(T) = 0'/> gives six conditions and a{" "}
+                <strong>quintic</strong> (fifth-order) time scaling,
+            </p>
+            <BlockMath math={`s(t) = 10\\Big(\\tfrac{t}{T}\\Big)^3 - 15\\Big(\\tfrac{t}{T}\\Big)^4 + 6\\Big(\\tfrac{t}{T}\\Big)^5`}/>
+            <p>
+                whose acceleration eases in and out of rest smoothly, removing the jerk spikes. The price is a higher
+                peak speed <InlineMath math='\dot s_\text{max} = \tfrac{15}{8T}'/> and peak acceleration{" "}
+                <InlineMath math='\tfrac{10}{\sqrt 3\,T^2}'/> — the arm must move a little faster in the middle to make
+                up for its gentler starts and stops. Selecting <em>quintic</em> in the figure above overlays the cubic
+                as a faint dashed reference so the difference in the <InlineMath math='\ddot s'/> plot is visible.
+            </p>
+
+            <h2>Trapezoidal and S-Curve Profiles</h2>
+            <p>
+                When the goal is the <em>fastest</em> straight-line motion under velocity and acceleration limits, the
+                polynomial scalings are wasteful — they touch their peak speed only for an instant. The{" "}
+                <strong>trapezoidal velocity profile</strong> instead accelerates at a constant{" "}
+                <InlineMath math='a'/>, <strong>coasts</strong> at a constant <InlineMath math='v'/>, then
+                decelerates at <InlineMath math='-a'/>. Its <InlineMath math='\dot s'/> is a trapezoid and its{" "}
+                <InlineMath math='s'/> is a parabola, then a line, then a parabola:
+            </p>
+            <BlockMath math={`\\dot s(t) = \\begin{cases} a\\,t, & 0 \\le t \\le v/a \\\\[2pt] v, & v/a < t \\le T - v/a \\\\[2pt] a\\,(T - t), & T - v/a < t \\le T \\end{cases}`}/>
+            <p>
+                With <InlineMath math='v'/> and <InlineMath math='a'/> set to the largest values the joints allow,
+                this is the time-optimal straight-line motion. The coast phase exists only while{" "}
+                <InlineMath math='v^2/a \le 1'/>; if <InlineMath math='v^2/a > 1'/> the trapezoid loses its flat top
+                and degenerates into a triangular <strong>bang-bang</strong> profile that accelerates for the first
+                half and decelerates for the second. Either way the acceleration is <strong>discontinuous</strong> at
+                the switching instants — finite, but with infinite jerk at each corner. Slide <InlineMath math='v'/>{" "}
+                in the trapezoidal figure to watch the coast phase widen, then collapse.
+            </p>
+            <p>
+                The <strong>S-curve</strong> profile smooths those corners by inserting constant-<em>jerk</em> ramps,
+                so the acceleration itself rises and falls linearly instead of stepping. This splits the motion into
+                seven stages (jerk up, constant accel, jerk down, coast, and the mirror image while decelerating) and
+                is the standard choice in motor control precisely because the bounded jerk avoids exciting vibration.
+            </p>
+
+            <h2>Via Point Trajectories</h2>
+            <p>
+                Sometimes the robot need not follow a prescribed path shape but must simply <strong>pass through</strong>{" "}
+                a sequence of <strong>via points</strong> at specified times — for example to clear obstacles or touch
+                a series of workpieces. Given <InlineMath math='k'/> via points at times{" "}
+                <InlineMath math='T_1 = 0, \dots, T_k = T'/>, each with a position <InlineMath math='\beta_i'/> and a
+                velocity <InlineMath math='\dot\beta_i'/>, one interpolates each joint history directly with a{" "}
+                <strong>piecewise cubic</strong>. On segment <InlineMath math='j'/> of duration{" "}
+                <InlineMath math='\Delta T_j = T_{j+1} - T_j'/>, with local time{" "}
+                <InlineMath math='\Delta t \in [0, \Delta T_j]'/>,{" "}
+                <InlineMath math='\beta(T_j + \Delta t) = a_{j0} + a_{j1}\Delta t + a_{j2}\Delta t^2 + a_{j3}\Delta t^3'/>{" "}
+                where
+            </p>
+            <BlockMath math={`a_{j0} = \\beta_j, \\quad a_{j1} = \\dot\\beta_j, \\quad a_{j2} = \\frac{3\\beta_{j+1} - 3\\beta_j - 2\\dot\\beta_j\\Delta T_j - \\dot\\beta_{j+1}\\Delta T_j}{\\Delta T_j^{\\,2}}, \\quad a_{j3} = \\frac{2\\beta_j + (\\dot\\beta_j + \\dot\\beta_{j+1})\\Delta T_j - 2\\beta_{j+1}}{\\Delta T_j^{\\,3}}`}/>
+            <p>
+                Matching each segment's endpoint position and velocity makes the assembled trajectory continuous in
+                both position and velocity at every via point, though <em>not</em> in acceleration — fifth-order
+                segments would fix that at the cost of more coefficients. The interior via{" "}
+                <strong>velocities</strong> are free parameters that shape the curve: reasonable choices round the
+                corners smoothly, while setting the velocities to zero at just two endpoints reduces the whole thing
+                to the straight-line cubic time scaling of the first section. Drag the sliders below to steer the two
+                interior via velocities and watch the path bend to follow them.
+            </p>
+            <ViaPointTrajectory/>
+        </>
+    )
+}
+
+export default Chapter9

--- a/document/src/pages/chapters/index.ts
+++ b/document/src/pages/chapters/index.ts
@@ -75,6 +75,39 @@ const data: IChapterData[] = [
             "Inverse Velocity Kinematics",
         ],
     },
+    {
+        chapter: 7,
+        title: "Kinematics of Closed Chains",
+        contents: lazy(() => import("./Chapter7")),
+        sections: [
+            "Closed Chains and Parallel Mechanisms",
+            "Forward and Inverse Kinematics",
+            "Differential Kinematics",
+            "Singularities",
+        ],
+    },
+    {
+        chapter: 8,
+        title: "Dynamics of Open Chains",
+        contents: lazy(() => import("./Chapter8")),
+        sections: [
+            "The Equations of Motion",
+            "Lagrangian Dynamics of a 2R Arm",
+            "Newton–Euler Inverse Dynamics",
+            "Forward Dynamics and Simulation",
+        ],
+    },
+    {
+        chapter: 9,
+        title: "Trajectory Generation",
+        contents: lazy(() => import("./Chapter9")),
+        sections: [
+            "Paths and Time Scaling",
+            "Polynomial Time Scaling",
+            "Trapezoidal and S-Curve Profiles",
+            "Via Point Trajectories",
+        ],
+    },
 ]
 
 export default data.sort((a, b) => a.chapter - b.chapter)


### PR DESCRIPTION
`MR.pdf` 목차에 따라 다음 3개 챕터를 추가합니다. 각 챕터는 기존 컨벤션(장별 인터랙티브 그림, `CanvasFigure`, `CoordinateCanvas`/`useCanvasColors`, 테마 대응)을 그대로 따릅니다.

## Chapter 7 — Kinematics of Closed Chains
절: Closed Chains and Parallel Mechanisms / Forward and Inverse Kinematics / Differential Kinematics / Singularities
- **FourBarLinkage** — 원-원 교차로 loop closure 를 풀고, ψ–θ configuration-space 패널에 bifurcation(구성공간 특이점)을 표시.
- **RPRParallel** — 3-RPR 평면 병렬기구. 플랫폼 pose 슬라이더 → leg 길이를 직접 계산해 역기구학이 trivial 함을 시연.

## Chapter 8 — Dynamics of Open Chains
절: The Equations of Motion / Lagrangian Dynamics of a 2R Arm / Newton–Euler Inverse Dynamics / Forward Dynamics and Simulation
- **TwoRDynamics** — 책의 점질량 방정식(M, c, g)을 그대로 적분하는 실시간 2R 순방향 동역학 시뮬레이터(semi-implicit Euler). τ 슬라이더·중력·중력보상 토글, double-pendulum 거동.
- **MassMatrixEllipse** — 자세에 따른 관성(가속도 타원) 변화.
- 두 그림이 같은 팔을 그리도록 팔 파라미터·질량행렬을 `chapter8/twoRModel.ts` 로 공유.

## Chapter 9 — Trajectory Generation
절: Paths and Time Scaling / Polynomial Time Scaling / Trapezoidal and S-Curve Profiles / Via Point Trajectories
- **TimeScalingProfiles** — cubic/quintic/trapezoidal 전환, s·ṡ·s̈ 플롯 + Play 애니메이션(jerk 차이 시각화).
- **ViaPointTrajectory** — piecewise-cubic via-point 보간. via 속도를 바꾸면 경로가 휘어짐.

## Verification
- `yarn build` 통과 (typecheck clean, 세 챕터 모두 코드 스플릿).
- 브라우저 실동작 확인: `?chapter=7/8/9` 로드 시 console error 0건, Ch8 시뮬레이터 자동 애니메이션·Ch9 프로파일 전환/Play 실동작 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
