### PR TITLE
docs: add MIT LICENSE and attribution/disclaimer notes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+MIT License
+
+Copyright (c) 2026 ladianchad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+NOTE ON THIRD-PARTY CONTENT
+
+The MIT license above covers the original source code of this project (the web
+app and sample code). It does not cover the underlying textbook. This project
+provides unofficial, non-commercial study notes based on Kevin M. Lynch and
+Frank C. Park's "Modern Robotics: Mechanics, Planning, and Control"
+(Cambridge University Press, 2017), which remains the copyright of its authors
+and publisher. This project is not affiliated with or endorsed by them. All
+explanatory text, code, and figures here are original work; the book's own
+text and figures are not reproduced or redistributed.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Interactive study notes for **Kevin M. Lynch & Frank C. Park's**
 
 ---
 
+> **Disclaimer.** These are unofficial, non-commercial study notes based on Kevin M. Lynch &
+> Frank C. Park's _Modern Robotics: Mechanics, Planning, and Control_ (Cambridge University Press,
+> 2017). This project is **not affiliated with or endorsed by** the authors or the publisher. All
+> explanatory text, code, and interactive figures here are original work; the book's own text and
+> figures are not reproduced, and the book PDF is not redistributed. Concepts, equations, and
+> algorithms are described in our own words and implementations.
+
+---
+
 ## Overview
 
 This repo has two parts:
@@ -163,4 +172,9 @@ interactive or animated figure, the way Chapter 2 does. When adding or expanding
 
 ## License
 
-[MIT](https://opensource.org/licenses/MIT)
+The original source code of this project (the web app and sample code) is released under the
+[MIT](https://opensource.org/licenses/MIT) license — see [`LICENSE`](./LICENSE).
+
+The MIT license covers only this project's own code. The underlying textbook, _Modern Robotics_
+by Lynch & Park (Cambridge University Press, 2017), remains the copyright of its authors and
+publisher and is **not** relicensed here.

--- a/document/src/components/Footer.tsx
+++ b/document/src/components/Footer.tsx
@@ -4,6 +4,7 @@ const Footer = () => (
     <footer className="site-footer">
         <p>modern robotics — interactive study notes on Lynch &amp; Park's <em>Modern Robotics</em></p>
         <p>Built as a static site · <a href={REPO} target="_blank" rel="noopener noreferrer">GitHub</a></p>
+        <p>Unofficial, non-commercial study notes · not affiliated with or endorsed by the authors or Cambridge University Press.</p>
     </footer>
 )
 


### PR DESCRIPTION
프로젝트가 Lynch & Park의 *Modern Robotics* 교과서 기반 비공식 학습 노트임을 명확히 하기 위해 라이선스·출처·면책 표기를 추가합니다.

## 변경
- **`LICENSE` 신설** — 프로젝트 자체 소스코드에 MIT 적용(README의 MIT 배지에 실제 파일이 없던 문제 해소). 하단에 교과서 콘텐츠는 relicense 대상이 아니며 저자·출판사 저작권임을 명시.
- **README** — 상단에 unofficial/비제휴 disclaimer blockquote 추가, License 절에서 "MIT는 프로젝트 자체 코드에만 적용"임을 명확화.
- **사이트 푸터** (`Footer.tsx`) — "Unofficial, non-commercial study notes · not affiliated with or endorsed by the authors or Cambridge University Press." 한 줄 추가.

## 의도
- 모든 해설·코드·인터랙티브 그림은 원작을 베끼지 않은 창작물이며, 책 원문/그림/PDF는 재현·재배포하지 않음을 문서로 분명히 함.
- 저작권은 표현을 보호하고 수식·개념은 자유롭게 서술 가능하다는 전제 위에서, 출처 표기와 비제휴 사실을 투명하게 밝힘.

## Verification
- `yarn build` 통과.
- 브라우저 확인: 푸터에 disclaimer 문구 정상 렌더, console error 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
